### PR TITLE
Update dependency expect-jsx to ^5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8240,12 +8240,6 @@
         }
       }
     },
-    "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-      "dev": true
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9343,14 +9337,28 @@
       }
     },
     "expect-jsx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/expect-jsx/-/expect-jsx-4.0.0.tgz",
-      "integrity": "sha512-Mu2s1LBsJOxFT6pj0dFXKpHxNdBfEXNOMA3LMuVOSyMGEetR02w4d3PUhSkuBKL4LSPUnCqf2dar7ilD0AAf8g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expect-jsx/-/expect-jsx-5.0.0.tgz",
+      "integrity": "sha1-YXYbQzZfKFqA6ygMeF4Hg7vjYsc=",
       "dev": true,
       "requires": {
         "collapse-white-space": "1.0.3",
-        "react": "15.6.2",
-        "react-element-to-jsx-string": "12.0.0"
+        "react": "16.2.0",
+        "react-element-to-jsx-string": "13.2.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+          "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        }
       }
     },
     "express": {
@@ -10769,9 +10777,9 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-own-enumerable-property-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-1.0.1.tgz",
-      "integrity": "sha1-8dTjrRQC4DmJjlbR6bmqkkwm5IQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -12128,9 +12136,9 @@
       }
     },
     "istanbul-instrumenter-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.0.tgz",
-      "integrity": "sha512-alLSEFX06ApU75sm5oWcaVNaiss/bgMRiWTct3g0P0ZZTKjR+6QiCcuVOKDI1kWJgwHEnIXsv/dWm783kPpmtw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.1.tgz",
+      "integrity": "sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==",
       "dev": true,
       "requires": {
         "convert-source-map": "1.5.1",
@@ -12148,6 +12156,15 @@
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
+          }
+        },
+        "schema-utils": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2"
           }
         }
       }
@@ -13801,42 +13818,6 @@
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
-        "babel-core": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.1",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.1",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.5",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
-          }
-        },
-        "babel-loader": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
-          "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
-          "requires": {
-            "find-cache-dir": "1.0.0",
-            "loader-utils": "1.1.0",
-            "mkdirp": "0.5.1"
-          }
-        },
         "babel-plugin-transform-class-properties": {
           "version": "6.24.1",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
@@ -14153,16 +14134,6 @@
             }
           }
         },
-        "find-cache-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-          "requires": {
-            "commondir": "1.0.1",
-            "make-dir": "1.2.0",
-            "pkg-dir": "2.0.0"
-          }
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -14383,14 +14354,6 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
             "pify": "2.3.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "requires": {
-            "find-up": "2.1.0"
           }
         },
         "read-pkg": {
@@ -16645,24 +16608,13 @@
       "dev": true
     },
     "react-element-to-jsx-string": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-12.0.0.tgz",
-      "integrity": "sha512-rk0FTRFHLspVZpkKd7tnf/fwXDcaII8mg1pQLRptrs5Yeg2TcQBUmsLBLDZMSCj/PWlj1/vw473wBIsc3WBx9A==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-13.2.0.tgz",
+      "integrity": "sha512-u994HvBg4YFlH48IfXts0gwA3ZnfAY4SAWISLyizdPL84xW5CIfvYfOq0bQdg3LCeLZNC+zkniAbqrr3mDXDVw==",
       "dev": true,
       "requires": {
-        "collapse-white-space": "1.0.3",
         "is-plain-object": "2.0.4",
-        "lodash": "4.17.4",
-        "sortobject": "1.1.1",
-        "stringify-object": "3.2.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
+        "stringify-object": "3.2.2"
       }
     },
     "react-event-listener": {
@@ -17310,12 +17262,33 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2"
+        "ajv": "6.4.0",
+        "ajv-keywords": "3.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        }
       }
     },
     "scss-loader": {
@@ -18113,15 +18086,6 @@
         "is-plain-obj": "1.1.0"
       }
     },
-    "sortobject": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sortobject/-/sortobject-1.1.1.tgz",
-      "integrity": "sha1-T2ldTUTtCkwGSCw0wlgqLc3CqzQ=",
-      "dev": true,
-      "requires": {
-        "editions": "1.3.4"
-      }
-    },
     "source-list-map": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
@@ -18523,12 +18487,12 @@
       }
     },
     "stringify-object": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.0.tgz",
-      "integrity": "sha1-lDcKE15BvASDWIE7+ZSB8TFcaqY=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "1.0.1",
+        "get-own-enumerable-property-symbols": "2.0.1",
         "is-obj": "1.0.1",
         "is-regexp": "1.0.0"
       }
@@ -18582,24 +18546,6 @@
         "schema-utils": "0.4.5"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
-          "dev": true
-        },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
@@ -18609,16 +18555,6 @@
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
-          }
-        },
-        "schema-utils": {
-          "version": "0.4.5",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-          "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.4.0",
-            "ajv-keywords": "3.1.0"
           }
         }
       }
@@ -19431,6 +19367,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "dev": true,
       "requires": {
         "punycode": "2.1.0"
       },
@@ -19438,7 +19375,8 @@
         "punycode": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
         }
       }
     },
@@ -19495,6 +19433,15 @@
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
+          }
+        },
+        "schema-utils": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-standard": "^3.0.0",
     "expect": "^1.20.2",
-    "expect-jsx": "^4.0.0",
+    "expect-jsx": "^5.0.0",
     "fetch": "^1.1.0",
     "fetch-mock": "6.3.0",
     "file-loader": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,7 +1938,7 @@ codecov@^3.0.0:
     request "2.81.0"
     urlgrey "0.4.4"
 
-collapse-white-space@1.0.3, collapse-white-space@^1.0.0:
+collapse-white-space@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
 
@@ -2692,10 +2692,6 @@ ecstatic@^3.0.0:
     minimist "^1.1.0"
     url-join "^2.0.2"
 
-editions@^1.1.1:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -3268,13 +3264,13 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect-jsx@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/expect-jsx/-/expect-jsx-4.0.0.tgz#bd1d3568f1da5d02c1b498bb773afd963dec3b46"
+expect-jsx@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/expect-jsx/-/expect-jsx-5.0.0.tgz#61761b43365f285a80eb280c785e0783bbe362c7"
   dependencies:
     collapse-white-space "^1.0.0"
-    react "^0.14.8 || ^15.0.1"
-    react-element-to-jsx-string "^12.0.0"
+    react "^16.0.0"
+    react-element-to-jsx-string "^13.0.0"
 
 expect@^1.20.2:
   version "1.20.2"
@@ -3709,9 +3705,9 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
-get-own-enumerable-property-symbols@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-1.0.1.tgz#f1d4e3ad1402e039898e56d1e9b9aa924c26e484"
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -5320,10 +5316,6 @@ lodash.upperfirst@4.3.1:
 lodash@3.9.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.9.3.tgz#0159e86832feffc6d61d852b12a953b99496bd32"
-
-lodash@4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 lodash@^3.10.0, lodash@^3.10.1, lodash@^3.8.0:
   version "3.10.1"
@@ -6958,15 +6950,12 @@ react-dom@^15.3.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-element-to-jsx-string@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-12.0.0.tgz#d6c02272cb2268b8b3d98272adf0a4462fd75019"
+react-element-to-jsx-string@^13.0.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-13.2.0.tgz#550bb9670e4d8c82977934c14db14469d156a70d"
   dependencies:
-    collapse-white-space "1.0.3"
     is-plain-object "2.0.4"
-    lodash "4.17.4"
-    sortobject "1.1.1"
-    stringify-object "3.2.0"
+    stringify-object "3.2.2"
 
 react-event-listener@^0.5.1:
   version "0.5.3"
@@ -7052,7 +7041,7 @@ react-transition-group@^1.2.1:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-"react@^0.14.8 || ^15.0.1", react@^15.4.0:
+react@^15.4.0:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
@@ -7061,6 +7050,15 @@ react-transition-group@^1.2.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -7835,12 +7833,6 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-sortobject@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.1.1.tgz#4f695d4d44ed0a4c06482c34c2582a2dcdc2ab34"
-  dependencies:
-    editions "^1.1.1"
-
 source-list-map@^0.1.7, source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
@@ -8033,11 +8025,11 @@ string_decoder@^1.0.0, string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringify-object@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.0.tgz#94370a135e41bc048358813bf99481f1315c6aa6"
+stringify-object@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.2.tgz#9853052e5a88fb605a44cd27445aa257ad7ffbcd"
   dependencies:
-    get-own-enumerable-property-symbols "^1.0.1"
+    get-own-enumerable-property-symbols "^2.0.1"
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 


### PR DESCRIPTION
This Pull Request updates dependency [expect-jsx](https://github.com/algolia/expect-jsx) from `^4.0.0` to `^5.0.0`



<details>
<summary>Release Notes</summary>

### [`v5.0.0`](https://github.com/algolia/expect-jsx/blob/master/CHANGELOG.md#&#8203;500httpsgithubcomalgoliaexpect-jsxcomparev400v500-2017-11-07)

### [4.0.0](https://github.com/algolia/expect-jsx/compare/v3.0.0...v4.0.0) (2017-09-18)

---

</details>


<details>
<summary>Commits</summary>

#### v5.0.0
-   [`ed15a5e`](https://github.com/algolia/expect-jsx/commit/ed15a5e92f86c2c34e860acc92e5366ded51ff9f) upgraded to dependencies to be able to use module on react 16 tests
-   [`5265311`](https://github.com/algolia/expect-jsx/commit/52653111d5a948a89be96e10a5b22cd96ff18611) Merge pull request #&#8203;30 from tuxtitlan/develop
-   [`34a3de1`](https://github.com/algolia/expect-jsx/commit/34a3de1377d70ef4ee3bcd2707de72e42de43e9b) bump done at release time
-   [`38f0a1f`](https://github.com/algolia/expect-jsx/commit/38f0a1f0cc664a22d4d0816d940d492ca5589449) 5.0.0

</details>