### PR TITLE
chore(deps): update dependency jsdom to ^11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -399,18 +399,18 @@
       }
     },
     "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "5.5.3"
       },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         }
       }
@@ -577,9 +577,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-html": {
@@ -2411,9 +2411,9 @@
       }
     },
     "bowser": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.3.tgz",
-      "integrity": "sha512-/gp96UlcFw5DbV2KQPCqTqi0Mb9gZRyDAHiDsGEH+4B/KOQjeoE5lM1PxlVX8DQDvfEfitmC1rW2Oy8fk/XBDg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.2.tgz",
+      "integrity": "sha512-fuiANC1Bqbqa/S4gmvfCt7bGBmNELMsGZj4Wg3PrP6esP66Ttoj1JSlzFlXtHyduMv07kDNmDsX6VsMWT/MLGg==",
       "dev": true
     },
     "brace-expansion": {
@@ -2453,6 +2453,12 @@
         "through2": "2.0.3",
         "umd": "3.0.3"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
     },
     "browser-resolve": {
       "version": "1.11.2",
@@ -3173,21 +3179,21 @@
       "dev": true
     },
     "clean-css": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
-      "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+      "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
       }
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-spinners": {
@@ -3240,14 +3246,6 @@
       "requires": {
         "slice-ansi": "0.0.4",
         "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "slice-ansi": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-          "dev": true
-        }
       }
     },
     "cli-width": {
@@ -8289,7 +8287,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.11"
+        "sha.js": "2.4.10"
       },
       "dependencies": {
         "ripemd160": {
@@ -8302,9 +8300,9 @@
           }
         },
         "sha.js": {
-          "version": "2.4.11",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "version": "2.4.10",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+          "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
           "requires": {
             "inherits": "2.0.3",
             "safe-buffer": "5.1.1"
@@ -8322,7 +8320,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "sha.js": "2.4.10"
       },
       "dependencies": {
         "ripemd160": {
@@ -8335,9 +8333,9 @@
           }
         },
         "sha.js": {
-          "version": "2.4.11",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "version": "2.4.10",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+          "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
           "requires": {
             "inherits": "2.0.3",
             "safe-buffer": "5.1.1"
@@ -8434,6 +8432,32 @@
         "source-list-map": "2.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
@@ -8445,11 +8469,48 @@
             "json5": "0.5.1"
           }
         },
+        "postcss-modules-extract-imports": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+          "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+          "dev": true,
+          "requires": {
+            "postcss": "6.0.21"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.21",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+              "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+              "dev": true,
+              "requires": {
+                "chalk": "2.3.2",
+                "source-map": "0.6.1",
+                "supports-color": "5.3.0"
+              }
+            }
+          }
+        },
         "source-list-map": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
           "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
         }
       }
     },
@@ -8598,7 +8659,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.39"
       }
     },
     "dargs": {
@@ -9001,6 +9062,15 @@
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "domhandler": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
@@ -9076,26 +9146,6 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
-      }
-    },
-    "ecstatic": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.2.0.tgz",
-      "integrity": "sha512-Goilx/2cfU9vvfQjgtNgc2VmJAD8CasQ6rZDqCd2u4Hsyd/qFET6nBf60jiHodevR3nl3IGzNKtrzPXWP88utQ==",
-      "dev": true,
-      "requires": {
-        "he": "1.1.1",
-        "mime": "1.4.1",
-        "minimist": "1.2.0",
-        "url-join": "2.0.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "editions": {
@@ -9306,13 +9356,12 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.39",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-symbol": "3.1.1"
       }
     },
     "es5-shim": {
@@ -9327,7 +9376,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.39",
         "es6-symbol": "3.1.1"
       }
     },
@@ -9337,7 +9386,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -9356,7 +9405,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -9374,7 +9423,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.39"
       }
     },
     "es6-templates": {
@@ -9419,7 +9468,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -9518,6 +9567,18 @@
           "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -9542,6 +9603,15 @@
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
           }
         },
         "cross-spawn": {
@@ -9574,6 +9644,15 @@
             "acorn-jsx": "3.0.1"
           }
         },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
         "globals": {
           "version": "11.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
@@ -9586,6 +9665,34 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.3.2",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.1.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.5",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "js-yaml": {
           "version": "3.11.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
@@ -9596,11 +9703,76 @@
             "esprima": "4.0.0"
           }
         },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+          "dev": true
+        },
         "progress": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
           "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
           "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -9618,6 +9790,20 @@
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "ajv-keywords": "2.1.1",
+            "chalk": "2.3.2",
+            "lodash": "4.17.5",
+            "slice-ansi": "1.0.0",
+            "string-width": "2.1.1"
           }
         }
       }
@@ -9645,9 +9831,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -9692,16 +9878,6 @@
           "requires": {
             "esutils": "2.0.2",
             "isarray": "1.0.0"
-          }
-        },
-        "eslint-module-utils": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-          "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "pkg-dir": "1.0.0"
           }
         },
         "find-up": {
@@ -9785,6 +9961,17 @@
         "has": "1.0.1",
         "jsx-ast-utils": "2.0.1",
         "prop-types": "15.6.0"
+      },
+      "dependencies": {
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+          "dev": true,
+          "requires": {
+            "array-includes": "3.0.3"
+          }
+        }
       }
     },
     "eslint-plugin-standard": {
@@ -9810,19 +9997,19 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
-      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.4.1",
+        "acorn": "5.5.3",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         }
       }
@@ -9872,7 +10059,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.39"
       }
     },
     "eventemitter3": {
@@ -10311,6 +10498,12 @@
         "path-to-regexp": "2.2.0"
       },
       "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz",
+          "integrity": "sha512-fyPCII4vn9Gvjq2U/oDAfP433aiE64cyP/CJjRJcpVGjqqNdioUYn9+r0cSzT1XPwmGAHuTT7iv+rQT8u/YHKQ==",
+          "dev": true
+        },
         "path-to-regexp": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.0.tgz",
@@ -10320,12 +10513,13 @@
       }
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-entry-cache": {
@@ -11750,12 +11944,6 @@
         "is-glob": "2.0.1"
       }
     },
-    "glob-to-regexp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz",
-      "integrity": "sha512-fyPCII4vn9Gvjq2U/oDAfP433aiE64cyP/CJjRJcpVGjqqNdioUYn9+r0cSzT1XPwmGAHuTT7iv+rQT8u/YHKQ==",
-      "dev": true
-    },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -12223,7 +12411,7 @@
       "requires": {
         "es6-templates": "0.2.3",
         "fastparse": "1.1.1",
-        "html-minifier": "3.5.12",
+        "html-minifier": "3.5.9",
         "loader-utils": "1.1.0",
         "object-assign": "4.1.1"
       },
@@ -12242,27 +12430,21 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
-      "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.9.tgz",
+      "integrity": "sha512-EZqO91XJwkj8BeLx9C12sKB/AHoTANaZax39vEOP9f/X/9jgJ3r1O2+neabuHqpz5kJO71TapP9JrtCY39su1A==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
-        "clean-css": "4.1.11",
-        "commander": "2.15.1",
+        "clean-css": "4.1.9",
+        "commander": "2.14.1",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.16"
+        "uglify-js": "3.3.12"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12270,12 +12452,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.3.16",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
-          "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
+          "version": "3.3.12",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.12.tgz",
+          "integrity": "sha512-4jxrTXlV0HaXTsNILfXW0eey7Qo8qHYM6ih5ZNh45erDWU2GHmKDmekwBTskDb12h+kdd2DBvdzqVb47YzNmTA==",
           "dev": true,
           "requires": {
-            "commander": "2.15.1",
+            "commander": "2.14.1",
             "source-map": "0.6.1"
           }
         }
@@ -12408,10 +12590,51 @@
         "union": "0.4.6"
       },
       "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
         "colors": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "ecstatic": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.2.0.tgz",
+          "integrity": "sha512-Goilx/2cfU9vvfQjgtNgc2VmJAD8CasQ6rZDqCd2u4Hsyd/qFET6nBf60jiHodevR3nl3IGzNKtrzPXWP88utQ==",
+          "dev": true,
+          "requires": {
+            "he": "1.1.1",
+            "mime": "1.4.1",
+            "minimist": "1.2.0",
+            "url-join": "2.0.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "portfinder": {
+          "version": "1.0.13",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+          "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "debug": "2.6.9",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "url-join": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+          "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
           "dev": true
         }
       }
@@ -12662,16 +12885,6 @@
         "source-map": "0.5.7"
       }
     },
-    "inline-style-prefixer": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-      "dev": true,
-      "requires": {
-        "bowser": "1.9.3",
-        "css-in-js-utils": "2.0.0"
-      }
-    },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -12694,6 +12907,12 @@
         "through": "2.3.8"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -12720,6 +12939,24 @@
             "supports-color": "5.3.0"
           }
         },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12731,6 +12968,31 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
         },
         "rx-lite": {
           "version": "4.0.8",
@@ -13510,9 +13772,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI=",
       "dev": true
     },
     "js-base64": {
@@ -13613,37 +13875,54 @@
       }
     },
     "jsdom": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-      "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
+        "acorn": "5.5.3",
+        "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
+        "browser-process-hrtime": "0.1.2",
         "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
+        "domexception": "1.0.1",
         "escodegen": "1.9.0",
         "html-encoding-sniffer": "1.0.2",
-        "nwmatcher": "1.4.3",
-        "parse5": "1.5.1",
+        "left-pad": "1.2.0",
+        "nwmatcher": "1.4.4",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
         "request": "2.83.0",
+        "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
         "tough-cookie": "2.3.3",
+        "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
+        "whatwg-url": "6.4.0",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
+        },
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
@@ -13755,15 +14034,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-      "dev": true,
-      "requires": {
-        "array-includes": "3.0.3"
       }
     },
     "karma": {
@@ -14254,6 +14524,12 @@
           "integrity": "sha512-A7PDg4s48MkqFEcYg2b069m3DXOEq7hx+9q9rIFrSSYfzsh35GX+LOVMQ8Au0ko7d8bSQCIAuzkjp0vCtwENlQ==",
           "dev": true
         },
+        "url-join": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+          "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+          "dev": true
+        },
         "webpack-dev-middleware": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
@@ -14347,6 +14623,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "left-pad": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -14422,16 +14704,6 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
         "log-symbols": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
@@ -14465,16 +14737,6 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
@@ -14502,43 +14764,6 @@
         "cli-cursor": "1.0.2",
         "date-fns": "1.29.0",
         "figures": "1.7.0"
-      },
-      "dependencies": {
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        }
       }
     },
     "load-json-file": {
@@ -14964,39 +15189,6 @@
       "requires": {
         "ansi-escapes": "1.4.0",
         "cli-cursor": "1.0.2"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        }
       }
     },
     "loggly": {
@@ -15418,6 +15610,48 @@
         "recompose": "0.26.0",
         "simple-assign": "0.1.0",
         "warning": "3.0.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w==",
+          "dev": true
+        },
+        "inline-style-prefixer": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+          "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+          "dev": true,
+          "requires": {
+            "bowser": "1.9.2",
+            "css-in-js-utils": "2.0.0"
+          }
+        },
+        "react-event-listener": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
+          "integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "fbjs": "0.8.16",
+            "prop-types": "15.6.0",
+            "warning": "3.0.0"
+          }
+        },
+        "recompose": {
+          "version": "0.26.0",
+          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+          "dev": true,
+          "requires": {
+            "change-emitter": "0.1.6",
+            "fbjs": "0.8.16",
+            "hoist-non-react-statics": "2.5.0",
+            "symbol-observable": "1.2.0"
+          }
+        }
       }
     },
     "materialize-css": {
@@ -15427,7 +15661,7 @@
       "dev": true,
       "requires": {
         "hammerjs": "2.0.8",
-        "jquery": "3.3.1"
+        "jquery": "2.2.4"
       }
     },
     "math-expression-evaluator": {
@@ -15951,9 +16185,9 @@
       }
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "nan": {
@@ -16849,11 +17083,6 @@
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
       "dev": true
     },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-    },
     "nice-try": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
@@ -17429,9 +17658,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true
     },
     "oauth-sign": {
@@ -17636,13 +17865,10 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.2.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
     },
     "open": {
       "version": "0.0.5",
@@ -17707,33 +17933,6 @@
         "cli-cursor": "1.0.2",
         "cli-spinners": "0.1.2",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        }
       }
     },
     "original": {
@@ -17998,9 +18197,9 @@
       "dev": true
     },
     "parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
     "parseqs": {
@@ -18122,7 +18321,7 @@
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "sha.js": "2.4.10"
       },
       "dependencies": {
         "ripemd160": {
@@ -18135,9 +18334,9 @@
           }
         },
         "sha.js": {
-          "version": "2.4.11",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "version": "2.4.10",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+          "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
           "requires": {
             "inherits": "2.0.3",
             "safe-buffer": "5.1.1"
@@ -18279,6 +18478,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "podda": {
@@ -18636,69 +18841,6 @@
         "postcss-selector-parser": "2.2.3"
       }
     },
-    "postcss-modules-extract-imports": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-      "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
-      "dev": true,
-      "requires": {
-        "postcss": "6.0.21"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.2",
-            "source-map": "0.6.1",
-            "supports-color": "5.3.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
-      }
-    },
     "postcss-modules-local-by-default": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
@@ -18706,27 +18848,27 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.21"
+        "postcss": "6.0.19"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
@@ -18736,14 +18878,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.2",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.3.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -18753,9 +18895,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -18770,27 +18912,27 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.21"
+        "postcss": "6.0.19"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
@@ -18800,14 +18942,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.2",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.3.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -18817,9 +18959,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -18834,27 +18976,27 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.21"
+        "postcss": "6.0.19"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
@@ -18864,14 +19006,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.19",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.2",
+            "chalk": "2.3.1",
             "source-map": "0.6.1",
-            "supports-color": "5.3.0"
+            "supports-color": "5.2.0"
           }
         },
         "source-map": {
@@ -18881,9 +19023,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -19375,18 +19517,6 @@
         "json-stringify-pretty-compact": "1.1.0"
       }
     },
-    "react-event-listener": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
-      "integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "fbjs": "0.8.16",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
-      }
-    },
     "react-fuzzy": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.3.3.tgz",
@@ -19482,7 +19612,7 @@
       "integrity": "sha1-AHo9FpR4qnEKSRcn5FPv+5LnYgM=",
       "dev": true,
       "requires": {
-        "mute-stream": "0.0.7"
+        "mute-stream": "0.0.5"
       }
     },
     "read-chunk": {
@@ -19592,26 +19722,6 @@
       "dev": true,
       "requires": {
         "resolve": "1.5.0"
-      }
-    },
-    "recompose": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-      "dev": true,
-      "requires": {
-        "change-emitter": "0.1.6",
-        "fbjs": "0.8.16",
-        "hoist-non-react-statics": "2.5.0",
-        "symbol-observable": "1.2.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w==",
-          "dev": true
-        }
       }
     },
     "redent": {
@@ -19853,6 +19963,26 @@
         "throttleit": "1.0.0"
       }
     },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      }
+    },
     "requestretry": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.13.0.tgz",
@@ -19964,13 +20094,13 @@
       }
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "ret": {
@@ -20640,21 +20770,10 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
-      }
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
     },
     "slide": {
       "version": "1.1.6",
@@ -21040,18 +21159,6 @@
         "standard-engine": "8.0.1"
       },
       "dependencies": {
-        "ajv-keywords": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-          "dev": true
-        },
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -21076,15 +21183,6 @@
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.3.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "2.0.0"
           }
         },
         "cross-spawn": {
@@ -21122,7 +21220,7 @@
             "doctrine": "2.1.0",
             "eslint-scope": "3.7.1",
             "eslint-visitor-keys": "1.0.0",
-            "espree": "3.5.3",
+            "espree": "3.5.4",
             "esquery": "1.0.0",
             "esutils": "2.0.2",
             "file-entry-cache": "2.0.0",
@@ -21152,27 +21250,6 @@
             "text-table": "0.2.0"
           }
         },
-        "eslint-import-resolver-node": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-          "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "resolve": "1.5.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
         "eslint-plugin-import": {
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
@@ -21184,7 +21261,7 @@
             "debug": "2.6.9",
             "doctrine": "1.5.0",
             "eslint-import-resolver-node": "0.3.2",
-            "eslint-module-utils": "2.1.1",
+            "eslint-module-utils": "2.2.0",
             "has": "1.0.1",
             "lodash": "4.17.5",
             "minimatch": "3.0.4",
@@ -21218,33 +21295,6 @@
           "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
           "dev": true
         },
-        "eslint-plugin-react": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-          "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
-          "dev": true,
-          "requires": {
-            "doctrine": "2.1.0",
-            "has": "1.0.1",
-            "jsx-ast-utils": "2.0.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "eslint-plugin-standard": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-          "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
-          "dev": true
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5"
-          }
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -21266,34 +21316,6 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.3.2",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.5",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "js-yaml": {
           "version": "3.11.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
@@ -21302,15 +21324,6 @@
           "requires": {
             "argparse": "1.0.10",
             "esprima": "4.0.0"
-          }
-        },
-        "jsx-ast-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-          "dev": true,
-          "requires": {
-            "array-includes": "3.0.3"
           }
         },
         "load-json-file": {
@@ -21325,21 +21338,6 @@
             "strip-bom": "3.0.0"
           }
         },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.2.0"
-          }
-        },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -21348,12 +21346,6 @@
           "requires": {
             "pify": "2.3.0"
           }
-        },
-        "pluralize": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-          "dev": true
         },
         "progress": {
           "version": "2.0.0",
@@ -21382,50 +21374,6 @@
             "read-pkg": "2.0.0"
           }
         },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "dev": true,
-          "requires": {
-            "is-promise": "2.1.0"
-          }
-        },
-        "rx-lite": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-          "dev": true
-        },
-        "slice-ansi": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -21442,20 +21390,6 @@
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
-          }
-        },
-        "table": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "ajv-keywords": "2.1.1",
-            "chalk": "2.3.2",
-            "lodash": "4.17.5",
-            "slice-ansi": "1.0.0",
-            "string-width": "2.1.1"
           }
         }
       }
@@ -21569,6 +21503,12 @@
       "requires": {
         "readable-stream": "2.3.4"
       }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -21925,6 +21865,12 @@
         "url-parse-as-address": "1.0.0"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -21949,6 +21895,24 @@
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
           }
         },
         "has-flag": {
@@ -21989,6 +21953,40 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
           "integrity": "sha1-G8K8cWWM3KVxJHVoQ2NhWwtPaVs=",
           "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -22113,6 +22111,15 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -22359,10 +22366,21 @@
       }
     },
     "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -22718,9 +22736,9 @@
       }
     },
     "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+      "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
       "dev": true
     },
     "url-loader": {
@@ -22987,6 +23005,15 @@
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
+      }
+    },
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
@@ -23146,6 +23173,12 @@
         "yeoman-generator": "2.0.3"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -23176,6 +23209,15 @@
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
           }
         },
         "cliui": {
@@ -23217,6 +23259,15 @@
             "graceful-fs": "4.1.11",
             "memory-fs": "0.4.1",
             "tapable": "1.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
           }
         },
         "find-up": {
@@ -23282,6 +23333,21 @@
             "readable-stream": "2.3.4"
           }
         },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
@@ -23291,6 +23357,25 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
           }
         },
         "string-width": {
@@ -24011,12 +24096,6 @@
             "has-flag": "3.0.0"
           }
         },
-        "url-join": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
-          "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
-          "dev": true
-        },
         "webpack-dev-middleware": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz",
@@ -24186,21 +24265,14 @@
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "whatwg-url": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
       "dev": true,
       "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        }
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "when": {
@@ -24335,9 +24407,9 @@
       "dev": true
     },
     "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "xregexp": {
@@ -24435,6 +24507,18 @@
         "untildify": "3.0.2"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -24455,6 +24539,15 @@
             "supports-color": "5.3.0"
           }
         },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -24469,6 +24562,15 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
           "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
         },
         "globby": {
           "version": "6.1.0",
@@ -24488,6 +24590,93 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.3.2",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.1.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.5",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         },
         "supports-color": {
           "version": "5.3.0",
@@ -24656,6 +24845,15 @@
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "3.0.0"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
           }
         },
         "shelljs": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "istanbul": "1.1.0-alpha.1",
     "istanbul-instrumenter-loader": "^3.0.0",
     "jasmine-core": "^3.0.0",
-    "jsdom": "^9.4.2",
+    "jsdom": "^11.0.0",
     "karma": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.0.2",


### PR DESCRIPTION
This Pull Request updates dependency [jsdom](https://github.com/jsdom/jsdom) from `^9.4.2` to `^11.0.0`



<details>
<summary>Release Notes</summary>

### [`v10.0.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1000)

This release includes a complete overhaul of jsdom's API for creating and manipulating jsdoms. The new API is meant to be much more intuitive and have better defaults, with complete documentation in the newly-overhauled README. We hope you like it!

As discussed in the new README, the old API is still available and supported via `require("jsdom/lib/old-api.js")`, at least until we have ported all of its features over to the new API. It will, however, not be gaining any new features, and we suggest you try the new API unless you really need the customizable resource loading the old API provides.

Apart from the new API, the following changes were made, with breaking changes bolded:

* **Removed support for Node.js v4 and v5**, as we have started using new JavaScript features only supported in Node.js v6 onwards.
* **Changed the `omitJsdomErrors` option to `omitJSDOMErrors`**, for consistency [with web platform APIs](https://w3ctag.github.io/design-principles/#casing-rules).
* Added `document.dir`. (Zirro)
* Updated the `<a>` and `<area>` APIs to the latest specification, and fixed a few bugs with them. (makana)
* Fixed `<img>` elements to no longer fire `"load"` events unless their image data is actually loaded (which generally only occurs when the `canvas` package is installed).
* Fixed `XMLHttpRequest` preflights to forward approved preflight headers to the actual request. (mbroadst)
* Fixed `htmlElement.dir` to properly restrict its values to `"ltr"`, `"rtl"`, or `"auto"`. (Zirro)
* Fixed setting `innerHTML` to the empty string to no longer be a no-op. (Zirro)
* Fixed the origin-checking logic in `window.postMessage()`, so that now you don't always have to pass an origin of `"*"`. (jmlopez-rod)
* Improved the `xhr.open()` error message when there are not enough arguments. (lencioni)

---

### [`v10.1.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1010)

* Added the value sanitization algorithm for password, search, tel, text, color, email, and url input types. (Zirro)
* Added `Symbol.toStringTag` to all web platform classes, so that now `Object.prototype.toString.call()` works as expected on jsdom objects.
* Added the `select.selectedOptions` property.
* Removed the `toString()` methods on various prototypes that returned `"[object ClassName]"` in an attempt to fake the `Symbol.toStringTag` behavior.
* Changed `XMLHttpRequest` to pre-allocate a 1 MiB buffer, which it grows exponentially as needed, in order to avoid frequent buffer allocation and concatenation. (skygon)
* Fixed a variety of properties that were meant to always return the same object, to actually do so. (Zirro)
* Fixed inheritance of the `runScripts` and `resources` options into iframes.
* Fixed an uncaught exception that occurred if you called `xhr.abort()` during a `"readystatechange"` event.

---

### [`v11.0.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1100)

Breaking changes:

* Custom parsers, via the `parser` option to the old API, can no longer be specified. They were never tested, often broken, and a maintenance burden. The defaults, of [parse5](https://www.npmjs.com/package/parse5) for HTML and [sax](https://www.npmjs.com/package/sax) for XML, now always apply.
* Due to a parse5 upgrade, the location info objects returned by `dom.nodeLocation()` or the old API's `jsdom.nodeLocation()` now have a different structure.
* Fixed how `runScripts` applies to event handler attributes; now they will no longer be converted into event handler functions unless `runScripts: "dangerously"` is set. However, event handler _properties_ will now work with any `runScripts` option value, instead of being blocked.

Other changes:

* Overhauled how event handler properties and attributes work to follow the spec. In particular, this adds various `oneventname` properties to various prototypes, ensures the correct order when interleaving event handlers and other event listeners, and ensures that event handlers are evaluated with the correct values in scope.
* Upgraded parse5 from v1 to v3, bringing along several correctness improvements to HTML parsing. (Zirro)
* Updated `Location` properties to be on the instance, instead of the prototype, and to be non-configurable.
* Significantly improved the performance of `HTMLCollection`, and thus of parsing large documents. (Zirro)
* Significantly improved the performance of `getComputedStyle()` by removing unsupported selectors from the default style sheet. (flaviut)
* Fixed all web platform methods that accepted web platform objects to perform proper type checks on them, throwing a `TypeError` when given invalid values. (TimothyGu)
* Fixed the `Symbol.toStringTag` properties to be non-writable and non-enumerable. (TimothyGu)
* Fixed `tokenList.remove()` when the `DOMTokenList` corresponded to a non-existant attribute. (Zirro)
* Fixed `fileReader.abort()` to terminate ongoing reads properly.
* Fixed `xhr.send()` to support array buffer views, not just `ArrayBuffer`s. (ondras)
* Fixed non-`GET` requests to `data:` URLs using `XMLHttpRequest`. (Zirro)
* Fixed form submission to no longer happen for disconnected forms.
* Fixed body event handler attributes to be treated like all others in terms of how they interact with `runScripts`.
* Many updates per recent spec changes: (Zirro)
  * Updated `tokenList.replace()` edge-case behavior.
  * Invalid qualified names now throw `"InvalidCharacterError"` `DOMException`s, instead of `"NamespaceError"` `DOMException`s.
  * Changed `input.select()` to no longer throw on types where selection does not apply.
  * Updated `event.initEvent()` and various related methods to have additional defaults.
  * Stopped lowercasing headers in `XMLHttpRequest` responses.
  * Started lowercasing headers in `xhr.getAllResponseHeaders()`, and separating the header values with a comma-space (not just a comma).
  * Allow a redirect after a CORS preflight when using `XMLHttpRequest`.
  * Tweaked username/password CORS treatment when using `XMLHttpRequest`.
  * Changed `xhr.overrideMimeType()` to no longer throw for invalid input.
  * Removed `blob.close()` and `blob.isClosed()`.
* Removed some remaining not-per-spec `toString()` methods on various prototypes, which were made redundant in v10.1.0 but we forgot to remove.

---

### [`v11.1.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1110)

* Added `javascript:` URL "navigation" via `window.location`, at least by evaluating the side effects. It still doesn't actually navigate anywhere. (ForbesLindesay)
* Updated `whatwg-url` to v6.1.0, bringing along origin serialization changes and `URLSearchParams` among various other fixes. (ForbesLindesay)
* Fixed `javascript:` URL loading for iframes to do proper percent-decoding and error reporting.
* Fixed corrupted `XMLHttpRequest` responses when they were over 1 MiB.
* Fixed timers to not start after a window is `close()`d, which could cause strange errors since most objects are unusable at that point. (Enverbalalic)

---

### [`v11.2.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1120)

This release brings with it a much-awaited infrastructure change, as part of [webidl2js v7.3.0](https://github.com/jsdom/webidl2js/releases/tag/v7.3.0) by the ever-amazing TimothyGu: jsdom can now generate spec-compliant versions of classes that have "`Proxy`-like" behavior, i.e. allow getting or setting keys in unusual ways. This enables a number of improvements, also by TimothyGu:

* Significantly improved the spec-compliance and "liveness" of both `NodeList` and `HTMLCollection`, such that retrieving properties via indices or (in `HTMLCollection`'s case) `id`/`name` values will always work correctly.
* Added `element.dataset` support.
* Added indexed and named access to `<select>` elements, as well as the corresponding `item()` and `namedItem()` methods.
* Added suport for `FileList` indexed properties, i.e. `fileList[i]`.
* Made `select.options` an instance of the newly-implemented `HTMLOptionsCollection`, instead of just a `HTMLCollection`.

This infrastructure will allow us to improve and implement many other similar behaviors; that work is being tracked in [#&#8203;1129](`https://github.com/tmpvar/jsdom/issues/1129`).

In addition to these improvements to the object model, we have more work to share:

* Added no-op APIs `document.clear()`, `document.captureEvents()`, `document.releaseEvents()`, `window.external.AddSearchProvider()`, and `window.external.IsSearchProviderInstalled()`. (Zirro)
* Added active checks to prevent reentrancy in `TreeWalker` and `NodeIterator`.
* Updated the interaction between a `<textarea>`'s `value`, `defaultValue`, and `textContent` per [a recent spec change](https://github.com/whatwg/html/commit/5afbba1cf62ee01bc6af3fd220d01f3f7591a0fc)
* Fixed elements with `id="undefined"` shadowing the `undefined` property of the global object. (TimothyGu)
* Fixed matching in `getElementsByClassName()` to be ASCII case-insensitive, instead of using JavaScript's `toLowerCase()`.
* Improved some behaviors around navigating to fragments. (ForbesLindesay)
* Improved `XMLHttpRequest` and `FileReader` behavior, mainly around event handlers, `abort()`, and network errors.
* Improved edge-case spec compliance of `NodeIterator`.

---

### [`v11.3.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1130)

For this release we'd like to formally welcome [@&#8203;TimothyGu](https://github.com/tmpvar/jsdom/commits?author=TimothyGu) to the core team, as a prolific contributor. He will join the illustrious ranks of those who do so much work on jsdom that we no longer note their names in the changelog.

* Added `table.tHead`, `table.tFoot`, and `table.caption` setters, and the `table.createTBody()` method.
* Added `CompositionEvent` and `WheelEvent` classes.
* Added a `<details>` element implementation. (Zirro)
* Added stub `<marquee>` and `<picture>` element implementations. (Zirro)
* Updated `uiEvent.initUIEvent()`, `keyboardEvent.initKeyboardEvent()`, and `mouseEvent.initiMouseEvent()` to match the latest specifications.
* Converted `DOMTokenList` (used by, e.g., `element.classList`) to use proxies for improved specification compliance and "liveness".
* Fixed the `DOMException` class to be spec-compliant, including its constructor signature.
* Fixed some subtle interactions between inline event handlers and other event listeners.
* Fixed the element interface used when creating many of the more obscure elements.
* Fixed the behavior of the `table.rows` getter, and the `table.createCaption()` and `table.deleteRow()` methods.
* Fixed incorrect sharing of methods between interfaces that used mixins (e.g. previously `document.querySelector === documentFragment.querySelector`, incorrectly).
* Fixed `FocusEvent` creation, which regressed in v11.2.0.
* Fixed `UIEvent` to only allow initializing with `Window` objects for its `view` property.
* Fixed the behavior of `tr.rowIndex` and `tr.deleteCall()`.
* Fixed the element interface for `<td>` and `<th>` to be simply `HTMLTableCellElement`, and improved that class's spec compliance.
* Fixed calling `label.click()` to not trigger the labeled control's activation behavior when the control is disabled. (schreifels)
* Fixed `document.getElementsByName()` to return a `NodeList` instead of a `HTMLCollection`. (Zirro)
* Significantly sped up synchronous `XMLHttpRequest`. (Zirro)

---

### [`v11.4.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1140)

For this release we'd like to welcome [@&#8203;Zirro](https://github.com/tmpvar/jsdom/commits?author=Zirro) to the core team; his contributions over the course of this year have enhanced jsdom immensely.

* Added a rudimentary set of SVG element classes, namely `SVGElement`, `SVGGraphicsElement`, `SVGSVGElement`, `SVGTests`, `SVGAnimatedString`, `SVGNumber`, and `SVGStringList`. The main impact here is that SVG elements are now instances of `SVGElement`, instead of being simply `Element` (as they were in v11.3.0) or `HTMLUnknownElement` (as they were in v11.2.0 and previously). The only concrete subclass that is implemented is `SVGSVGElement`, for `<svg>` itself; other tags will not map to their correct classes, because those classes are not yet implemented.
* Added the new `pretendToBeVisual` option, which controls the presence of the new `requestAnimationFrame()` and `cancelAnimationFrame()` methods, and the new values of `document.hidden`/`document.visibilityState`. [See the README](https://github.com/tmpvar/jsdom#pretending-to-be-a-visual-browser) for more information. (SimenB)
* Added the `append()` and `prepend()` methods to `Document`, `DocumentFragment`, and `Element`. (caub)
* Added the `before()`, `after()`, and `replaceWith()` methods to `DocumentType`, `Element`, and `CharacterData`. (caub)
* Added `node.isConnected`.
* Added `node.isSameNode()`.
* Added support for parsing CDATA sections in XML documents, including in `domParser.parseFromString()`. (myabc)
* Added appropriate `input.value` getter/setter logic for `<input type="file">`.
* Significantly improved the spec-compliance of `NamedNodeMap`, i.e. of `element.attributes`, such that retrieving named or indexed properties will now always work properly.
* Fixed `domParser.parseFromString()` to not parse HTML character entities in XML documents. (myabc)
* Fixed `xhr.abort()` to clear any set headers.
* Fixed `XMLHttpRequest` to always decoded responses as UTF-8 when `responseType` is set to `"json"`.
* Fixed `XMLHttpRequest` CORS header handling, especially with regard to preflights and Access-Control-Allow-Headers. (ScottAlbertine)
* Fixed the behavior of `radioButton.click()` to fire appropriate `input` and `change` events. (liqwid)
* Fixed `querySelector()`/`querySelectorAll()` behavior for SVG elements inside `<template>` contents `DocumentFragment`s, including those created by `JSDOM.fragment()`. (caub)
* Fixed the line number reporting in exception stack traces when using `<script>` elements, when `includeNodeLocations` is set.
* Removed the `<applet>` element, [following the spec](`https://github.com/whatwg/html/pull/1399`).

---

### [`v11.5.1`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1151)

(This should have been a minor release; oops.)

* Added `AbortSignal` and `AbortController`.
* Fixed validation for file `<input>`s and implemented validation for more input types.

---

### [`v11.6.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1160)

* Added a fully-functioning `WebSocket` implementation!
* Added a `window.performance` implementation, including the basics of the [High Resolution Time](https://w3c.github.io/hr-time/) specification: `performance.now()`, `performance.timeOrigin`, and `performance.toJSON()`.
* Added support for all of the public API of `HTMLMeterElement`, except for `meterEl.labels`.
* Added the `locationbar`, `menubar`, `personalbar`, `scrollbars`, `statusbar`, and `toolbar` properties to `Window`.
* Added more properties to `window.screen`: `availWidth`, `availHeight`, `colorDepth`, and `pixelDepth`. All of its properties are now getters as well.
* Added `window.devicePixelRatio`.
* Added `getModifierState()` to `MouseEvent` and `KeyboardEvent`.
* Added a setter for `HTMLInputElement`'s `files` property.
* Added support for the `endings` option to the `Blob` constructor.
* Fixed firing various event firings to have the correct default values, e.g. the properties of `MouseEvent` when using `element.click()`.
* Fixed the firing of `popstate` and `hashchange` events during fragment navigation to make them trusted events.
* Fixed `data:` URL parsing to not include the fragment portions.
* Fixed all URL-accepting properties to properly perform [scalar value string conversion](https://infra.spec.whatwg.org/#javascript-string-convert) and URL resolution.
* Fixed many other small edge-case conformance issues in the API surface of various web APIs; see [#&#8203;2053](`https://github.com/tmpvar/jsdom/pull/2053`) and [#&#8203;2081](`https://github.com/tmpvar/jsdom/pull/2081`) for more information.
* Fixed various APIs to use ASCII lowercasing, instead of Unicode lowercasing, for element and attribute names.
* Fixed the encoding of a document created via `new Document()` to be UTF-8.
* Fixed event handler properties behavior when given non-callable objects.
* Increased the performance of parsing HTML documents with large numbers of sibling elements.
* Removed `probablySupportsContext()` and `setContext()` from `HTMLCanvasElement`, per spec updates.
* Removed the nonstandard `window.scrollLeft` and `window.scrollTop` properties, and the `window.createPopup()` method.

---

### [`v11.6.1`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1161)

* Fixed one regression (since v11.6.0) in `<style>` elements, where their `sheet` property would sometimes be `null` when it should not be.
* Fixed a case where a `<style>` element's `sheet` property would be left as a `CSSStyleSheet` despite it not being in the document.

Another regression remains where we are emitting spurious CSS-parsing `"jsdomError"` events; see [#&#8203;2123](`https://github.com/tmpvar/jsdom/issues/2123`). We also discovered a large amount of preexisting brokenness around `<style>`, `<link>`, and `@import`; see [#&#8203;2124](`https://github.com/tmpvar/jsdom/issues/2124`) for more details.

We'll try to fix these soon, especially the regression.

---

### [`v11.6.2`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1162)

* Fixed another regression (since v11.6.0) in `<style>` elements, where they would omit a series of parsing `"jsdomError"`s for any style sheet text containing spaces.
* Generally improved the spec-conformance of when `<style>` and `<script>` elements are evaluated; for example, `<script>` elements inserted by `innerHTML` are no longer evaluated.

---

### [`v11.7.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1170)

* Added the boolean return value to `DOMTokenList`'s `replace()` method, per the recent spec addition.
* Added `FileReader`'s `readAsBinaryString()` method, as it has been added back to the specification.
* Fixed event handlers to be own properties of each `Window`, instead of on `Window.prototype`. (Fetz)
* Fixed an exception that would sometimes get raised when removing an `<img>` element's `src=""` attribute. (atsikov)
* Fixed `"abort"` events on `AbortSignal`s to have their `isTrusted` set to true.
* Fixed some argument conversions in `XMLHttpRequest`'s `open()` method.
* Improved MIME type and data: URL parsing throughout jsdom, by using the new [`whatwg-mimetype`](https://www.npmjs.com/package/whatwg-mimetype) and [`data-urls`](https://www.npmjs.com/package/data-urls) packages.

---

</details>


<details>
<summary>Commits</summary>

#### v11.4.0
-   [`2456d60`](https://github.com/jsdom/jsdom/commit/2456d6053bf472347892ab0dbf68047b91c4e0c0) Yarn followup
-   [`a3594bc`](https://github.com/jsdom/jsdom/commit/a3594bcc3746604c37b55347616fd15a2169bd05) Correct DOMParser parsing of HTML entities in XML
-   [`8a6894c`](https://github.com/jsdom/jsdom/commit/8a6894c34f14b9131d0fe4acadb71dae4f49daca) Add {request,cancel}AnimationFrame and pretendToBeVisual
-   [`089afa8`](https://github.com/jsdom/jsdom/commit/089afa8773a1409c0e74ad24cc64a279faf8debf) Teach jsdom to parse XML CDATA sections
-   [`87e9593`](https://github.com/jsdom/jsdom/commit/87e95931cb8ad1b509a96daa9f6f59987ed5c3cf) Skip stack trace line number test in browsers
-   [`7a73cf6`](https://github.com/jsdom/jsdom/commit/7a73cf6bee906c3553fb8b7fd7238dc37528535f) Update contributor name to .mailmap; update AUTHORS.txt
-   [`ef2a5ec`](https://github.com/jsdom/jsdom/commit/ef2a5ec94c90e419a69ecdbba97c41f9debbb4eb) Fix needs-* checks in tests
-   [`54ea97b`](https://github.com/jsdom/jsdom/commit/54ea97bdf489b101c75e62d2ecc8a60c49e202b5) Allow mixing in symbols
-   [`c33816b`](https://github.com/jsdom/jsdom/commit/c33816baeeb801448fe0b82286fb4f71278862a2) Refactor HTMLElement
-   [`e2ea031`](https://github.com/jsdom/jsdom/commit/e2ea031fd763cd65dcd152f915f844a9ad74fb5d) A better SVG implementation
-   [`1e5434c`](https://github.com/jsdom/jsdom/commit/1e5434c3f42765df7bf13a25632fb23de9323dcd) Test that we are not mutating the passed-in options object
-   [`e5c2e32`](https://github.com/jsdom/jsdom/commit/e5c2e324f42d37bdd24c10a2f41662036d1375ef) Fix typo in README
-   [`6164c93`](https://github.com/jsdom/jsdom/commit/6164c93266c9a70fb5003c5d7a2608a9766e9ed2) Fix broken link to Attr.webidl in Contributing.md
-   [`d4612e7`](https://github.com/jsdom/jsdom/commit/d4612e7dff4355c633f5687d95f3c8f64575fcd1) Roll web-platform-tests
-   [`d13922a`](https://github.com/jsdom/jsdom/commit/d13922a2a5b09612d019c807fe3532d351c394f1) Clear headers on XHR abort()
-   [`e7b68fa`](https://github.com/jsdom/jsdom/commit/e7b68fa33db497aa1ddb5dbfc14f2bc53242e3a8) Add &lt;input&gt; value handling for the filename mode
-   [`587151f`](https://github.com/jsdom/jsdom/commit/587151f2f1536b9626ff4bbfd431ab39552640bf) Always decode responseType &quot;json&quot; as UTF-8
-   [`2b70aef`](https://github.com/jsdom/jsdom/commit/2b70aefc1b7ccbf2ac81e46f94febd55662093d8) Implement Node.isConnected and Node.isSameNode()
-   [`d12bea1`](https://github.com/jsdom/jsdom/commit/d12bea1fe419fec4895650122c3f5175e6496a4f) List execution-timing tests as failing in Node 6
-   [`b5b5dba`](https://github.com/jsdom/jsdom/commit/b5b5dba29e06cf42e1a517d8fb12a171912b877a) Disable tests we are not going to be able to pass this roll
-   [`d6cba38`](https://github.com/jsdom/jsdom/commit/d6cba380fcb61ee39e26099900825982e22d8b64) Convert NamedNodeMap to use IDL
-   [`f0ecb6d`](https://github.com/jsdom/jsdom/commit/f0ecb6d17a53adfe8d0fabd4915271e36ae420a1) Fix some XMLHttpRequest CORS header issues
-   [`fefbd7a`](https://github.com/jsdom/jsdom/commit/fefbd7ae8947d16c9085f262b281f6c274ba6b6e) Give radio buttons activation behavior too, not just checkboxes
-   [`35775cc`](https://github.com/jsdom/jsdom/commit/35775ccb77b40e7c42997b6c9adf69e34fd78c08) Don&#x27;t do radio button activation behavior if it&#x27;s already checked
-   [`f08fd3b`](https://github.com/jsdom/jsdom/commit/f08fd3bc81d9b10bc37f2d007cf2dfcd92aa0a6a) Fix querySelector for SVG elements inside template fragments
-   [`1b91696`](https://github.com/jsdom/jsdom/commit/1b9169659246ab394b4418061c1db1c3c65ecc81) Add append(), prepend(), after(), before(), and replaceWith()
-   [`f61299c`](https://github.com/jsdom/jsdom/commit/f61299c592bfdfeaac688bcf248a84dfe1587f8b) Remove the &lt;applet&gt; element
-   [`cef555a`](https://github.com/jsdom/jsdom/commit/cef555ae75bbfdf8bebea3af8ca7908ecb9ee3ff) Version 11.4.0
#### v11.5.0
-   [`ea6a0be`](https://github.com/jsdom/jsdom/commit/ea6a0be06ff9966c5af49a8ea830c6807bbdd7af) Small fixes to the changelog
-   [`87b7f11`](https://github.com/jsdom/jsdom/commit/87b7f11dc0aa9ed03331da300ab9831cd609ca0c) Add a reset-wpt script
-   [`1b72d6c`](https://github.com/jsdom/jsdom/commit/1b72d6c450c11483a226a9fc0d1558d78637a30b) Implement AbortController and AbortSignal
-   [`f8a6d12`](https://github.com/jsdom/jsdom/commit/f8a6d1215ca74036a4c93409857ef2372feb167e) Enhance &lt;input&gt;.value support for exotic types
-   [`26edf1c`](https://github.com/jsdom/jsdom/commit/26edf1c53e2ad7049b645328df56ef67f716c7c1) Implement &lt;input type&#x3D;checkbox&gt;.indeterminate
-   [`b921820`](https://github.com/jsdom/jsdom/commit/b921820a89ba13bca0b4dadf18776b5a97cacd7b) More comprehensive messages about &lt;input&gt; test failures
#### v11.5.1
-   [`4e7dcca`](https://github.com/jsdom/jsdom/commit/4e7dccaf336798573b03179992134b650ffa97ab) Version 11.5.1
#### v11.6.0
-   [`ad921b2`](https://github.com/jsdom/jsdom/commit/ad921b255f96d4ae87d66209f9a0f1e353486a21) Start web platform tests server before tests run
-   [`b8f4cc1`](https://github.com/jsdom/jsdom/commit/b8f4cc16a69296259e973d0bfdb3f94b98d2132c) Don&#x27;t include fragment in data: URL body
-   [`224d286`](https://github.com/jsdom/jsdom/commit/224d28614bb8bb5f012c61545edd3767583d3d10) Update dependencies
-   [`704f545`](https://github.com/jsdom/jsdom/commit/704f545e008b355d3feee0da59b8fac4115038e9) Update to new webidl2js
-   [`8d060a8`](https://github.com/jsdom/jsdom/commit/8d060a88b6073d2be825e43d30933d5a2e44ac0c) Update all Web IDL in nodes/
-   [`ff6ee3f`](https://github.com/jsdom/jsdom/commit/ff6ee3fd165dbabac8d3965f8822790fff8d96d8) Remove obsolete &lt;canvas&gt; methods
-   [`98950bc`](https://github.com/jsdom/jsdom/commit/98950bcded2b0e82272d2b6ad2b74141421e2f9e) Add a setter for inputEl.files
-   [`0052c6c`](https://github.com/jsdom/jsdom/commit/0052c6c2e41556c96b283f28825311b07a0e0db9) Update EventHandlers according to their IDL
-   [`d4d1cfe`](https://github.com/jsdom/jsdom/commit/d4d1cfea86d894ed665911dca0b39b626df56c0b) Handle USVString reflection
-   [`4c7698f`](https://github.com/jsdom/jsdom/commit/4c7698f760fc64f20b2a0ddff450eddbdd193176) Remove old longDesc test which no longer seems correct
-   [`aeca582`](https://github.com/jsdom/jsdom/commit/aeca58248f16b8e3eca81fd0690735ea586a2afb) Enable &#x27;option-text-setter&#x27; test which passes
-   [`05a6deb`](https://github.com/jsdom/jsdom/commit/05a6deb6b91b4e02c53ce240116146e59f7e14d7) Update yarn.lock
-   [`0c8f4eb`](https://github.com/jsdom/jsdom/commit/0c8f4eb701395c0d0ace9a37b7c48e0a2c7c5f90) Give failing tests on Travis a second chance
-   [`b65716c`](https://github.com/jsdom/jsdom/commit/b65716c3af5a2ccdadd73de41f41d075cea01bb8) Implement BarProp (Browser interface elements)
-   [`31bdee1`](https://github.com/jsdom/jsdom/commit/31bdee1cfd5ef8505b59dd625d5867ced2de260c) Implement the Screen interface
-   [`9622508`](https://github.com/jsdom/jsdom/commit/9622508ecf062ab853a7c460d2da4dbc79b46224) Implement window.devicePixelRatio
-   [`0463f71`](https://github.com/jsdom/jsdom/commit/0463f713927f0ccbe3312342cbc8616278b5ff8f) Enable certain tests for CSSOM View
-   [`30dc938`](https://github.com/jsdom/jsdom/commit/30dc938d3ab2e96a1853ee64ab97dcdf106a7288) Add note regarding the window.status attribute
-   [`bf9fab1`](https://github.com/jsdom/jsdom/commit/bf9fab17742b2971a9be45bcc97cd0002b672e6e) Use ASCII lowercase for localName and getElementsByTagName()
-   [`5bc6b3b`](https://github.com/jsdom/jsdom/commit/5bc6b3bbcc0f18eccecca551bfcfe7d6bbe3e2ba) Set Document&#x27;s default encoding to UTF-8
-   [`b9f127b`](https://github.com/jsdom/jsdom/commit/b9f127b0501a5e839ba1879eb1543c2616f616d8) Remove non-standard window.scrollLeft/scrollTop properties
-   [`39043e9`](https://github.com/jsdom/jsdom/commit/39043e947fac289d62a527f4cc08f83578685e8b) Add note regarding window.screenLeft/screenTop
-   [`f7f0b80`](https://github.com/jsdom/jsdom/commit/f7f0b80a84ce7c4b01b8e206de3fce8091df0bd4) Remove non-standard window.createPopup() stub
-   [`9b5d91f`](https://github.com/jsdom/jsdom/commit/9b5d91f8135cf9eb25ea90cd6b92c236355cf8df) Implement BlobPropertyBag#endings
-   [`2cf02a8`](https://github.com/jsdom/jsdom/commit/2cf02a84d2c4d30afb8691083aad28efae03bb66) Make HashChangeEvent and PopStateEvent trusted
-   [`e7fc3a9`](https://github.com/jsdom/jsdom/commit/e7fc3a938f7e5ec783f365f0d31165cf772c92c9) Roll whatwg-url
-   [`7e5e7dc`](https://github.com/jsdom/jsdom/commit/7e5e7dcdf639313119ce8a642e2d84617468929e) Allow non-callable objects for event IDL attributes
-   [`cb8ea4c`](https://github.com/jsdom/jsdom/commit/cb8ea4ca5667d799aa7be84565e24e1785bda54e) Roll WPT
-   [`fffa146`](https://github.com/jsdom/jsdom/commit/fffa146aea937d3a3a9386db524bc76b46e27d42) Protect against global mutation in Event classes
-   [`71d869d`](https://github.com/jsdom/jsdom/commit/71d869dccc6751e11f04847ad2156b1a1dcfecaa) Copy default params in Event constructor
-   [`4fa53f6`](https://github.com/jsdom/jsdom/commit/4fa53f626f7cdcc3e5f4308f06dc9cff57d7694f) Implement Keyboard/MouseEvent#getModifierState
-   [`9bb9297`](https://github.com/jsdom/jsdom/commit/9bb929712f951035304800980d08af58fb697f92) Set view attribute in HTMLElement#click
-   [`2b5447a`](https://github.com/jsdom/jsdom/commit/2b5447a5126116664a59557e2a56d4a14b0a6d24) Enable currently passing uievents WPTs
-   [`144b39b`](https://github.com/jsdom/jsdom/commit/144b39b726eabde92abdfaa362cd68f1d544d138) Implement WebSocket
-   [`1519104`](https://github.com/jsdom/jsdom/commit/1519104a1d0eea69e13b4c18c222a559d20829cb) Update Web IDL outside nodes/
-   [`e2ddfb7`](https://github.com/jsdom/jsdom/commit/e2ddfb7a9048df2155dc651f571c53145fdd3189) Implement more parts of &lt;meter&gt;
-   [`8c84ebf`](https://github.com/jsdom/jsdom/commit/8c84ebf3b7f3420b6e6cc68612ed3e0b9c1f4455) Overhaul HTML parsing infrastructure
-   [`ecdf27c`](https://github.com/jsdom/jsdom/commit/ecdf27cc3a17970aee508bf95e9268d3d9625a26) Upgrade parse5 to v4.0.0
-   [`b9dac94`](https://github.com/jsdom/jsdom/commit/b9dac947fcc54498200677308bfc36b296388a10) Upgrade in-range dependencies
-   [`12a5e12`](https://github.com/jsdom/jsdom/commit/12a5e12e3942bdb821c156ef0159bdb9f39cf4b2) Implement window.performance
-   [`cb523d1`](https://github.com/jsdom/jsdom/commit/cb523d1c7a4349ba75e79ca9825d92882ccb13fa) Add documentation about &quot;yarn pretest&quot;
-   [`9f1c9aa`](https://github.com/jsdom/jsdom/commit/9f1c9aa4063ac91aba2a1f8d382b0f89e2fa46c1) Make WebSocket compatible with browsers
-   [`ad0e551`](https://github.com/jsdom/jsdom/commit/ad0e551b1b633e07d11f98d7a30287491958def3) Fix hr-time tests after WPT roll
-   [`dc150a1`](https://github.com/jsdom/jsdom/commit/dc150a182db8cb17a682e21073c43efd9e0ad2a0) Version 11.6.0
#### v11.6.1
-   [`0c54ed3`](https://github.com/jsdom/jsdom/commit/0c54ed399b7399d3ab86e8a9d59fa7ea34e060da) Fix &lt;style&gt;&#x27;s sheet property
-   [`450b915`](https://github.com/jsdom/jsdom/commit/450b915cc68b6581b9b26a312837fa993ef8b4cd) Version 11.6.1
#### v11.6.2
-   [`dbda070`](https://github.com/jsdom/jsdom/commit/dbda070c9d33fb2762abedc23376757d9f8ec7d3) Fix &lt;style&gt; and &lt;script&gt; parsing to wait for their close tag
-   [`f32113b`](https://github.com/jsdom/jsdom/commit/f32113b6e1307832eb75d295d9da8185dd27006a) Further fix &lt;style&gt; and &lt;script&gt; evaluation semantics
-   [`71dc01b`](https://github.com/jsdom/jsdom/commit/71dc01b6f3c425bd395751648bf46bf55a13b79d) Update maintainer and repository information
-   [`1cd4831`](https://github.com/jsdom/jsdom/commit/1cd4831e36b40c8041237d5cf184f229f358ffc0) Version 11.6.2
#### v11.7.0
-   [`475a7cd`](https://github.com/jsdom/jsdom/commit/475a7cde88df30a2d38bff583ebcc5bc5a6880f6) Omit *.webidl from the published package
-   [`a0b7f8a`](https://github.com/jsdom/jsdom/commit/a0b7f8a77789fbc4467031a19865a2d1aef27796) Remove no-longer-used field from HTMLStyleElementImpl
-   [`830a6fd`](https://github.com/jsdom/jsdom/commit/830a6fdab5af9041f901a2316e7c74e8d88d91a2) Fix event handlers to be own properties of each Window
-   [`d563965`](https://github.com/jsdom/jsdom/commit/d5639655d32d45b6690c9ac30901136e650eb99a) Use whatwg-mimetype and data-urls packages
-   [`dc672a2`](https://github.com/jsdom/jsdom/commit/dc672a2544bd269cfbf311ae7ab0d06aa4d8d170) Fix removing an &lt;img&gt;&#x27;s src&#x3D;&quot;&quot; attribute
-   [`c520198`](https://github.com/jsdom/jsdom/commit/c52019862dc8f427a7f91455a64e50cc36a3ca6c) Implement requestAnimationFrame using performance.now
-   [`70ec93b`](https://github.com/jsdom/jsdom/commit/70ec93b436daf6d5b1d79a738226106819d25dc1) Add README entry about jsdom-devtools-formatter
-   [`a38c181`](https://github.com/jsdom/jsdom/commit/a38c181be8011c0ff9e05657a6485fd54a104fd0) Cross-reference external script loading from script execution docs
-   [`c91440a`](https://github.com/jsdom/jsdom/commit/c91440a97bc826ae79627655f860c66a63583007) Update web platform tests
-   [`d80648f`](https://github.com/jsdom/jsdom/commit/d80648f8854a168d33eec16bbac453ebbf0b4820) Set abort event isTrusted to true
-   [`5e86716`](https://github.com/jsdom/jsdom/commit/5e8671643bb0f0cc8e23c382c431ac8424736e88) Implement FileReader.readAsBinaryString()
-   [`8ad6b17`](https://github.com/jsdom/jsdom/commit/8ad6b17de8e48db5d7a1a6cbd2660968bb5c16f3) Convert several of XHR open()&#x27;s arguments to strings
-   [`7f41ae5`](https://github.com/jsdom/jsdom/commit/7f41ae54417492d9a111ce4c24e08cc2cc917a4c) Return boolean from DOMTokenList.replace()
-   [`8767d9f`](https://github.com/jsdom/jsdom/commit/8767d9f923b382f250b9b571fdb6d8f4d54adad1) Note that FileAPI/historical.https.html needs async/await
-   [`1e5bbd2`](https://github.com/jsdom/jsdom/commit/1e5bbd2638902a878c563e6e0e7a475d1bd37517) Version 11.7.0

</details>