### PR TITLE
chore(deps): update dependency mocha to ^5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -211,7 +211,7 @@
         "@kadira/storybook-ui": "3.11.0",
         "airbnb-js-shims": "1.4.1",
         "autoprefixer": "6.7.7",
-        "babel-core": "6.26.0",
+        "babel-core": "6.22.1",
         "babel-loader": "6.4.1",
         "babel-plugin-react-docgen": "1.8.2",
         "babel-preset-react-app": "1.0.0",
@@ -244,51 +244,6 @@
         "webpack-hot-middleware": "2.21.0"
       },
       "dependencies": {
-        "babel-loader": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
-          "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
-          "dev": true,
-          "requires": {
-            "find-cache-dir": "0.1.1",
-            "loader-utils": "0.2.17",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "css-loader": {
-          "version": "0.26.4",
-          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.4.tgz",
-          "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "css-selector-tokenizer": "0.7.0",
-            "cssnano": "3.10.0",
-            "loader-utils": "1.1.0",
-            "lodash.camelcase": "4.3.0",
-            "object-assign": "4.1.1",
-            "postcss": "5.2.18",
-            "postcss-modules-extract-imports": "1.2.0",
-            "postcss-modules-local-by-default": "1.2.0",
-            "postcss-modules-scope": "1.1.0",
-            "postcss-modules-values": "1.3.0",
-            "source-list-map": "0.1.8"
-          },
-          "dependencies": {
-            "loader-utils": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-              "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-              "dev": true,
-              "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1"
-              }
-            }
-          }
-        },
         "file-loader": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
@@ -297,12 +252,6 @@
           "requires": {
             "loader-utils": "0.2.17"
           }
-        },
-        "mime": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-          "dev": true
         },
         "postcss-loader": {
           "version": "1.1.0",
@@ -323,29 +272,6 @@
           "dev": true,
           "requires": {
             "loader-utils": "0.2.17"
-          }
-        },
-        "url-loader": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-          "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
-          "dev": true,
-          "requires": {
-            "loader-utils": "1.1.0",
-            "mime": "1.3.6"
-          },
-          "dependencies": {
-            "loader-utils": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-              "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-              "dev": true,
-              "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1"
-              }
-            }
           }
         }
       }
@@ -682,7 +608,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true,
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
@@ -732,7 +657,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
       "requires": {
         "arr-flatten": "1.1.0"
       }
@@ -822,8 +746,7 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "array.prototype.flatmap": {
       "version": "1.2.0",
@@ -954,9 +877,9 @@
       "dev": true
     },
     "atob": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -1060,6 +983,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.1",
@@ -1134,6 +1058,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -1177,6 +1102,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -1248,6 +1174,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -1282,6 +1209,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
       "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+      "dev": true,
       "requires": {
         "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
@@ -1292,6 +1220,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
           "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "dev": true,
           "requires": {
             "commondir": "1.0.1",
             "make-dir": "1.2.0",
@@ -1302,6 +1231,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
           "requires": {
             "locate-path": "2.0.0"
           }
@@ -1310,6 +1240,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
           "requires": {
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
@@ -1320,6 +1251,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
           "requires": {
             "find-up": "2.1.0"
           }
@@ -1356,7 +1288,8 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
@@ -1390,7 +1323,8 @@
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
     },
     "babel-plugin-syntax-export-extensions": {
       "version": "6.13.0",
@@ -1418,7 +1352,8 @@
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
     },
     "babel-plugin-transform-async-generator-functions": {
       "version": "6.24.1",
@@ -1435,6 +1370,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -1694,6 +1630,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -1881,7 +1818,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -1913,7 +1849,6 @@
           "version": "6.23.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
           "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
           }
@@ -1922,7 +1857,6 @@
           "version": "6.24.1",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
           "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-          "dev": true,
           "requires": {
             "babel-helper-call-delegate": "6.24.1",
             "babel-helper-get-function-arity": "6.24.1",
@@ -1936,7 +1870,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
           "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-          "dev": true,
           "requires": {
             "regenerator-transform": "0.10.1"
           }
@@ -2496,7 +2429,6 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
@@ -3121,7 +3053,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true,
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
@@ -8958,9 +8889,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -9179,7 +9110,8 @@
     "electron-to-chromium": {
       "version": "1.3.34",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz",
-      "integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0="
+      "integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0=",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -10175,7 +10107,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
       "requires": {
         "is-posix-bracket": "0.1.1"
       }
@@ -10184,7 +10115,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
       "requires": {
         "fill-range": "2.2.3"
       }
@@ -10361,7 +10291,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -10537,6 +10466,24 @@
         "schema-utils": "0.4.5"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
@@ -10546,6 +10493,16 @@
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
+          }
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+          "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
           }
         }
       }
@@ -10559,8 +10516,7 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fileset": {
       "version": "2.0.3",
@@ -10576,7 +10532,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
@@ -10678,7 +10633,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
       "requires": {
         "for-in": "1.0.2"
       }
@@ -11901,7 +11855,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
@@ -11911,7 +11864,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
       "requires": {
         "is-glob": "2.0.1"
       }
@@ -12503,9 +12455,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
-      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
       "dev": true
     },
     "http-proxy": {
@@ -13073,8 +13025,7 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal": {
       "version": "1.5.5",
@@ -13099,7 +13050,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -13112,8 +13062,7 @@
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -13141,7 +13090,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -13169,7 +13117,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -13258,6 +13205,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "3.0.1"
       },
@@ -13265,21 +13213,20 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -13410,7 +13357,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -13500,15 +13446,6 @@
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
-          }
-        },
-        "schema-utils": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.2"
           }
         }
       }
@@ -15571,7 +15508,6 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
       "requires": {
         "arr-diff": "2.0.0",
         "array-unique": "0.2.1",
@@ -15689,64 +15625,63 @@
       "dev": true
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
         "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+          "dev": true
+        },
         "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -16072,6 +16007,42 @@
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
+        "babel-core": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.5",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "babel-loader": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
+          "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+          "requires": {
+            "find-cache-dir": "1.0.0",
+            "loader-utils": "1.1.0",
+            "mkdirp": "0.5.1"
+          }
+        },
         "babel-plugin-transform-class-properties": {
           "version": "6.24.1",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
@@ -16388,6 +16359,16 @@
             }
           }
         },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
+          }
+        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -16610,6 +16591,14 @@
             "pify": "2.3.0"
           }
         },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -16826,29 +16815,6 @@
         "selenium-standalone": "5.11.2",
         "webpack": "1.15.0",
         "webpack-dev-server": "1.16.5"
-      },
-      "dependencies": {
-        "webpack-dev-server": {
-          "version": "1.16.5",
-          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
-          "integrity": "sha1-DL1fLSrI1OWTqs1clwLnu9XlmJI=",
-          "dev": true,
-          "requires": {
-            "compression": "1.7.2",
-            "connect-history-api-fallback": "1.5.0",
-            "express": "4.16.2",
-            "http-proxy-middleware": "0.17.4",
-            "open": "0.0.5",
-            "optimist": "0.6.1",
-            "serve-index": "1.9.1",
-            "sockjs": "0.3.19",
-            "sockjs-client": "1.1.4",
-            "stream-cache": "0.0.2",
-            "strip-ansi": "3.0.1",
-            "supports-color": "3.2.3",
-            "webpack-dev-middleware": "1.12.2"
-          }
-        }
       }
     },
     "no-case": {
@@ -17517,7 +17483,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
@@ -17889,7 +17854,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
       "requires": {
         "glob-base": "0.3.0",
         "is-dotfile": "1.0.3",
@@ -18836,8 +18800,7 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
       "version": "1.11.1",
@@ -19027,7 +18990,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -19037,7 +18999,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -19046,7 +19007,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
               }
@@ -19057,7 +19017,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -19513,7 +19472,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
@@ -19918,33 +19876,12 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
       "requires": {
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.1.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
-          "dev": true
-        }
+        "ajv": "5.5.2"
       }
     },
     "scoped-regex": {
@@ -20700,7 +20637,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
-        "atob": "2.0.3",
+        "atob": "2.1.0",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -21049,12 +20986,6 @@
         "readable-stream": "2.3.4"
       }
     },
-    "stream-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
-      "integrity": "sha1-GsWtaDJCjKVWZ9ve45Xa1ObbEY8=",
-      "dev": true
-    },
     "stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -21241,6 +21172,24 @@
         "schema-utils": "0.4.5"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
@@ -21250,6 +21199,16 @@
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
+          }
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+          "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
           }
         }
       }
@@ -22225,15 +22184,6 @@
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
           }
-        },
-        "schema-utils": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.2"
-          }
         }
       }
     },
@@ -22707,12 +22657,6 @@
             "which": "1.3.0"
           }
         },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        },
         "enhanced-resolve": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
@@ -23026,12 +22970,6 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "braces": {
@@ -23508,28 +23446,6 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
-        "portfinder": {
-          "version": "1.0.13",
-          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
-          "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "debug": "2.6.9",
-            "mkdirp": "0.5.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -23737,7 +23653,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.11",
+        "http-parser-js": "0.4.10",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -24060,12 +23976,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
         },
         "figures": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "karma-webpack": "^2.0.2",
     "material-ui": "^0.20.0",
     "materialize-css": "0.100.2",
-    "mocha": "^3.0.2",
+    "mocha": "^5.0.0",
     "nightwatch-autorun": "^3.0.3",
     "node-sass": "^4.0.0",
     "postcss-loader": "^1.0.0",


### PR DESCRIPTION
This Pull Request updates dependency [mocha](https://github.com/mochajs/mocha) from `^3.0.2` to `^5.0.0`



<details>
<summary>Release Notes</summary>

### [`v4.0.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;400--2017-10-02)

You might want to read this before filing a new bug!  :stuck_out_tongue_closed_eyes:
#### :boom: Breaking Changes

For more info, please [read this article](https://boneskull.com/mocha-v4-nears-release/).
##### Compatibility

- [#&#8203;3016]: Drop support for unmaintained versions of Node.js ([@&#8203;boneskull]):
  - 0.10.x
  - 0.11.x
  - 0.12.x
  - iojs (any)
  - 5.x.x
- [#&#8203;2979]: Drop support for non-ES5-compliant browsers ([@&#8203;boneskull]):
  - IE7
  - IE8
  - PhantomJS 1.x
- [#&#8203;2615]: Drop Bower support; old versions (3.x, etc.) will remain available ([@&#8203;ScottFreeCode], [@&#8203;boneskull])
##### Default Behavior

- [#&#8203;2879]: By default, Mocha will no longer force the process to exit once all tests complete.  This means any test code (or code under test) which would normally prevent `node` from exiting will do so when run in Mocha.  Supply the `--exit` flag to revert to pre-v4.0.0 behavior ([@&#8203;ScottFreeCode], [@&#8203;boneskull])
##### Reporter Output

- [#&#8203;2095]: Remove `stdout:` prefix from browser reporter logs ([@&#8203;skeggse])
- [#&#8203;2295]: Add separator in "unified diff" output ([@&#8203;olsonpm])
- [#&#8203;2686]: Print failure message when `--forbid-pending` or `--forbid-only` is specified ([@&#8203;ScottFreeCode])
- [#&#8203;2814]: Indent contexts for better readability when reporting failures ([@&#8203;charlierudolph])
#### :-1: Deprecations

- [#&#8203;2493]: The `--compilers` command-line option is now soft-deprecated and will emit a warning on `STDERR`.  Read [this](https://github.com/mochajs/mocha/wiki/compilers-deprecation) for more info and workarounds ([@&#8203;ScottFreeCode], [@&#8203;boneskull])
#### :tada: Enhancements

- [#&#8203;2628]: Allow override of default test suite name in XUnit reporter ([@&#8203;ngeor])
#### :book: Documentation

- [#&#8203;3020]: Link to CLA in `README.md` and `CONTRIBUTING.md` ([@&#8203;skeggse])
#### :nut_and_bolt: Other

- [#&#8203;2890]: Speed up build by (re-)consolidating SauceLabs tests ([@&#8203;boneskull])

[#&#8203;3016]: `https://github.com/mochajs/mocha/issues/3016`
[#&#8203;2979]: `https://github.com/mochajs/mocha/issues/2979`
[#&#8203;2615]: `https://github.com/mochajs/mocha/issues/2615`
[#&#8203;2879]: `https://github.com/mochajs/mocha/issues/2879`
[#&#8203;2095]: `https://github.com/mochajs/mocha/issues/2095`
[#&#8203;2295]: `https://github.com/mochajs/mocha/issues/2295`
[#&#8203;2686]: `https://github.com/mochajs/mocha/issues/2686`
[#&#8203;2814]: `https://github.com/mochajs/mocha/pull/2814`
[#&#8203;2493]: `https://github.com/mochajs/mocha/issues/2493`
[#&#8203;2628]: `https://github.com/mochajs/mocha/issues/2628`
[#&#8203;3020]: `https://github.com/mochajs/mocha/pull/3020`
[#&#8203;2890]: `https://github.com/mochajs/mocha/issues/2890`
[@&#8203;skeggse]: https://github.com/skeggse
[@&#8203;olsonpm]: https://github.com/olsonpm
[@&#8203;ngeor]: https://github.com/ngeor

---

### [`v4.0.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;401--2017-10-05)

#### :bug: Fixes

- [#&#8203;3051]: Upgrade Growl to v1.10.3 to fix its [peer dep problems](`https://github.com/tj/node-growl/pull/68`) ([@&#8203;dpogue])

[#&#8203;3051]: `https://github.com/mochajs/mocha/pull/3051`
[@&#8203;dpogue]: https://github.com/dpogue

---

### [`v4.1.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;410--2017-12-28)

This is mainly a "housekeeping" release.

Welcome [@&#8203;Bamieh] and [@&#8203;xxczaki] to the team!
#### :bug: Fixes

- [#&#8203;2661]: `progress` reporter now accepts reporter options ([@&#8203;canoztokmak])
- [#&#8203;3142]: `xit` in `bdd` interface now properly returns its `Test` object ([@&#8203;Bamieh])
- [#&#8203;3075]: Diffs now computed eagerly to avoid misinformation when reported ([@&#8203;abrady0])
- [#&#8203;2745]: `--help` will now help you even if you have a `mocha.opts` ([@&#8203;Zarel])
#### :tada: Enhancements

- [#&#8203;2514]: The `--no-diff` flag will completely disable diff output ([@&#8203;CapacitorSet])
- [#&#8203;3058]: All "setters" in Mocha's API are now also "getters" if called without arguments ([@&#8203;makepanic])
#### :book: Documentation

- [#&#8203;3170]: Optimization and site speed improvements ([@&#8203;Munter])
- [#&#8203;2987]: Moved the old [site repo](https://github.com/mochajs/mochajs.github.io) into the main repo under `docs/` ([@&#8203;boneskull])
- [#&#8203;2896]: Add [maintainer guide](https://github.com/mochajs/mocha/blob/master/MAINTAINERS.md) ([@&#8203;boneskull])
- Various fixes and updates ([@&#8203;xxczaki], [@&#8203;maty21], [@&#8203;leedm777])
#### :nut_and_bolt: Other

- Test improvements and fixes ([@&#8203;eugenet8k], [@&#8203;ngeor], [@&#8203;38elements], [@&#8203;Gerhut], [@&#8203;ScottFreeCode], [@&#8203;boneskull])
- Refactoring and cruft excision ([@&#8203;38elements], [@&#8203;Bamieh], [@&#8203;finnigantime], [@&#8203;boneskull])

[#&#8203;2661]: `https://github.com/mochajs/mocha/issues/2661`
[#&#8203;3142]: `https://github.com/mochajs/mocha/issues/3142`
[#&#8203;3075]: `https://github.com/mochajs/mocha/pull/3075`
[#&#8203;2745]: `https://github.com/mochajs/mocha/issues/2745`
[#&#8203;2514]: `https://github.com/mochajs/mocha/issues/2514`
[#&#8203;3058]: `https://github.com/mochajs/mocha/issues/3058`
[#&#8203;3170]: `https://github.com/mochajs/mocha/pull/3170`
[#&#8203;2987]: `https://github.com/mochajs/mocha/issues/2987`
[#&#8203;2896]: `https://github.com/mochajs/mocha/issues/2896`
[@&#8203;canoztokmak]: https://github.com/canoztokmak
[@&#8203;Bamieh]: https://github.com/Bamieh
[@&#8203;abrady0]: https://github.com/abrady0
[@&#8203;Zarel]: https://github.com/Zarel
[@&#8203;CapacitorSet]: https://github.com/CapacitorSet
[@&#8203;xxczaki]: https://github.com/xxczaki
[@&#8203;maty21]: https://github.com/maty21
[@&#8203;leedm777]: https://github.com/leedm777
[@&#8203;eugenet8k]: https://github.com/eugenet8k
[@&#8203;38elements]: https://github.com/38elements
[@&#8203;Gerhut]: https://github.com/Gerhut
[@&#8203;finnigantime]: https://github.com/finnigantime

---

### [`v5.0.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;500--2018-01-17)

Mocha starts off 2018 right by again dropping support for *unmaintained rubbish*.

Welcome [@&#8203;vkarpov15] to the team!
#### :boom: Breaking Changes

- **[#&#8203;3148]: Drop support for IE9 and IE10** ([@&#8203;Bamieh])
  Practically speaking, only code which consumes (through bundling or otherwise) the userland [buffer](https://npm.im/buffer) module should be affected.  However, Mocha will no longer test against these browsers, nor apply fixes for them.
#### :tada: Enhancements

- [#&#8203;3181]: Add useful new `--file` command line argument ([documentation](https://mochajs.org/#--file-file)) ([@&#8203;hswolff])
#### :bug: Fixes

- [#&#8203;3187]: Fix inaccurate test duration reporting ([@&#8203;FND])
- [#&#8203;3202]: Fix bad markup in HTML reporter ([@&#8203;DanielRuf])
#### :sunglasses: Developer Experience

- [#&#8203;2352]: Ditch GNU Make for [nps](https://npm.im/nps) to manage scripts ([@&#8203;TedYav])
#### :book: Documentation

- [#&#8203;3137]: Add missing `--no-timeouts` docs ([@&#8203;dfberry])
- [#&#8203;3134]: Improve `done()` callback docs ([@&#8203;maraisr])
- [#&#8203;3135]: Fix cross-references ([@&#8203;vkarpov15])
- [#&#8203;3163]: Fix tpyos ([@&#8203;tbroadley])
- [#&#8203;3177]: Tweak `README.md` organization ([@&#8203;xxczaki])
- Misc updates ([@&#8203;boneskull])
#### :nut_and_bolt: Other

- [#&#8203;3118]: Move TextMate Integration to [its own repo](https://github.com/mochajs/mocha.tmbundle) ([@&#8203;Bamieh])
- [#&#8203;3185]: Add Node.js v9 to build matrix; remove v7 ([@&#8203;xxczaki])
- [#&#8203;3172]: Markdown linting ([@&#8203;boneskull])
- Test & Netlify updates ([@&#8203;Munter], [@&#8203;boneskull])

[#&#8203;3148]: `https://github.com/mochajs/mocha/issues/3148`
[#&#8203;3181]: `https://github.com/mochajs/mocha/issues/3181`
[#&#8203;3187]: `https://github.com/mochajs/mocha/issues/3187`
[#&#8203;3202]: `https://github.com/mochajs/mocha/pull/3202`
[#&#8203;2352]: `https://github.com/mochajs/mocha/issues/2352`
[#&#8203;3137]: `https://github.com/mochajs/mocha/issues/3137`
[#&#8203;3134]: `https://github.com/mochajs/mocha/issues/3134`
[#&#8203;3135]: `https://github.com/mochajs/mocha/issues/3135`
[#&#8203;3163]: `https://github.com/mochajs/mocha/pull/3163`
[#&#8203;3177]: `https://github.com/mochajs/mocha/pull/3177`
[#&#8203;3118]: `https://github.com/mochajs/mocha/issues/3118`
[#&#8203;3185]: `https://github.com/mochajs/mocha/issues/3185`
[#&#8203;3172]: `https://github.com/mochajs/mocha/issues/3172`
[@&#8203;hswolff]: https://github.com/hswolff
[@&#8203;FND]: https://github.com/FND
[@&#8203;DanielRuf]: https://github.com/DanielRuf
[@&#8203;TedYav]: https://github.com/TedYav
[@&#8203;dfberry]: https://github.com/dfberry
[@&#8203;maraisr]: https://github.com/maraisr
[@&#8203;vkarpov15]: https://github.com/vkarpov15
[@&#8203;tbroadley]: https://github.com/tbroadley

---

### [`v5.0.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;501--2018-02-07)

...your garden-variety patch release.

Special thanks to [Wallaby.js](https://wallabyjs.com) for their continued support! :heart:
#### :bug: Fixes

- [#&#8203;1838]: `--delay` now works with `.only()` ([@&#8203;silviom])
- [#&#8203;3119]: Plug memory leak present in v8 ([@&#8203;boneskull])
#### :book: Documentation

- [#&#8203;3132], [#&#8203;3098]: Update `--glob` docs ([@&#8203;outsideris])
- [#&#8203;3212]: Update [Wallaby.js](https://wallabyjs.com)-related docs ([@&#8203;ArtemGovorov])
- [#&#8203;3205]: Remove outdated cruft ([@&#8203;boneskull])
#### :nut_and_bolt: Other

- [#&#8203;3224]: Add proper Wallaby.js config ([@&#8203;ArtemGovorov])
- [#&#8203;3230]: Update copyright year ([@&#8203;josephlin55555])

[#&#8203;1838]: `https://github.com/mochajs/mocha/issues/1838`
[#&#8203;3119]: `https://github.com/mochajs/mocha/issues/3119`
[#&#8203;3132]: `https://github.com/mochajs/mocha/issues/3132`
[#&#8203;3098]: `https://github.com/mochajs/mocha/issues/3098`
[#&#8203;3212]: `https://github.com/mochajs/mocha/pull/3212`
[#&#8203;3205]: `https://github.com/mochajs/mocha/pull/3205`
[#&#8203;3224]: `https://github.com/mochajs/mocha/pull/3224`
[#&#8203;3230]: `https://github.com/mochajs/mocha/pull/3230`
[@&#8203;silviom]: https://github.com/silviom
[@&#8203;outsideris]: https://github.com/outsideris
[@&#8203;ArtemGovorov]: https://github.com/ArtemGovorov
[@&#8203;josephlin55555]: https://github.com/josephlin55555

---

### [`v5.0.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;502--2018-03-05)

This release fixes a class of tests which report as *false positives*.  **Certain tests will now break**, though they would have previously been reported as passing.  Details below.  Sorry for the inconvenience!
#### :bug: Fixes

- [#&#8203;3226]: Do not swallow errors that are thrown asynchronously from passing tests ([@&#8203;boneskull]).  Example:

  ```js
  it('should actually fail, sorry!', function (done) {
    // passing assertion
    assert(true === true);

    // test complete & is marked as passing
    done();

    // ...but something evil lurks within
    setTimeout(() => {
      throw new Error('chaos!');
    }, 100);
  });
  ```

  Previously to this version, Mocha would have *silently swallowed* the `chaos!` exception, and you wouldn't know.  Well, *now you know*.  Mocha cannot recover from this gracefully, so it will exit with a nonzero code.

  **Maintainers of external reporters**: *If* a test of this class is encountered, the `Runner` instance will emit the `end` event *twice*; you *may* need to change your reporter to use `runner.once('end')` intead of `runner.on('end')`.
- [#&#8203;3093]: Fix stack trace reformatting problem ([@&#8203;outsideris])
#### :nut_and_bolt: Other

- [#&#8203;3248]: Update `browser-stdout` to v1.3.1 ([@&#8203;honzajavorek])

[#&#8203;3248]: `https://github.com/mochajs/mocha/issues/3248`
[#&#8203;3226]: `https://github.com/mochajs/mocha/issues/3226`
[#&#8203;3093]: `https://github.com/mochajs/mocha/issues/3093`
[@&#8203;honzajavorek]: https://github.com/honzajavorek

---

### [`v5.0.3`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;503--2018-03-06)

This patch features a fix to address a potential "low severity" [ReDoS vulnerability](https://snyk.io/vuln/npm:diff:20180305) in the [diff](https://npm.im/diff) package (a dependency of Mocha).
#### :lock: Security Fixes

- [#&#8203;3266]: Bump `diff` to v3.5.0 ([@&#8203;anishkny])
#### :nut_and_bolt: Other

- [#&#8203;3011]: Expose `generateDiff()` in `Base` reporter ([@&#8203;harrysarson])

[#&#8203;3266]: `https://github.com/mochajs/mocha/pull/3266`
[#&#8203;3011]: `https://github.com/mochajs/mocha/issues/3011`

[@&#8203;anishkny]: https://github.com/anishkny
[@&#8203;harrysarson]: https://github.com/harrysarson

---

### [`v5.0.4`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;504--2018-03-07)

#### :bug: Fixes

- [#&#8203;3265]: Fixes regression in "watch" functionality introduced in v5.0.2 ([@&#8203;outsideris])

[#&#8203;3265]: `https://github.com/mochajs/mocha/issues/3265`

---

### [`v5.0.5`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;505--2018-03-22)

Welcome [@&#8203;outsideris] to the team!
#### :bug: Fixes

- [#&#8203;3096]: Fix `--bail` failing to bail within hooks ([@&#8203;outsideris])
- [#&#8203;3184]: Don't skip too many suites (using `describe.skip()`) ([@&#8203;outsideris])
#### :book: Documentation

- [#&#8203;3133]: Improve docs regarding "pending" behavior ([@&#8203;ematicipo])
- [#&#8203;3276], [#&#8203;3274]: Fix broken stuff in `CHANGELOG.md` ([@&#8203;tagoro9], [@&#8203;honzajavorek])
#### :nut_and_bolt: Other

- [#&#8203;3208]: Improve test coverage for AMD users ([@&#8203;outsideris])
- [#&#8203;3267]: Remove vestiges of PhantomJS from CI ([@&#8203;anishkny])
- [#&#8203;2952]: Fix a debug message ([@&#8203;boneskull])

[#&#8203;3096]: `https://github.com/mochajs/mocha/issues/3096`
[#&#8203;3184]: `https://github.com/mochajs/mocha/issues/3184`
[#&#8203;3133]: `https://github.com/mochajs/mocha/issues/3133`
[#&#8203;3276]: `https://github.com/mochajs/mocha/pull/3276`
[#&#8203;3274]: `https://github.com/mochajs/mocha/pull/3274`
[#&#8203;3208]: `https://github.com/mochajs/mocha/issues/3208`
[#&#8203;2952]: `https://github.com/mochajs/mocha/issues/2952`
[#&#8203;3267]: `https://github.com/mochajs/mocha/pull/3267`

[@&#8203;ematicipo]: https://github.com/ematicipo
[@&#8203;tagoro9]: https://github.com/tagoro9
[@&#8203;honzajavorek]: https://github.com/honajavorek
[@&#8203;anishkny]: https://github.com/anishkny

---

</details>


<details>
<summary>Commits</summary>

#### v4.1.0
-   [`a4b684d`](https://github.com/mochajs/mocha/commit/a4b684dfaf5bb0c915415f32d0179aa929609c54) Added netlify header auto generation
-   [`4b18851`](https://github.com/mochajs/mocha/commit/4b188511a1101afe01c44bf4c1337585d075d5d4) Externalise js bundles
-   [`d5a5125`](https://github.com/mochajs/mocha/commit/d5a512563d0e845b57a2fed1320b120cb51a1067) Be explicit about styling of screenshot images
-   [`8f1ded4`](https://github.com/mochajs/mocha/commit/8f1ded4e82b36df67b84347199adffe03fe8ffbe) https urls where possible
-   [`64deadc`](https://github.com/mochajs/mocha/commit/64deadce3b4175eb41c965e1fa8024b2d11e9c5a) Specific value for inlining htmlimages to guarantee logo is inlined
-   [`123ee4f`](https://github.com/mochajs/mocha/commit/123ee4f42388700eb16c85630ae23a3e298bc70f) Handle the case where all avatars are already loaded at the time when the script exexecutes
-   [`bd5109e`](https://github.com/mochajs/mocha/commit/bd5109eb7e53c5996b7e2a748e37f6afce9ba808) Remove crossorigin&#x3D;&#x27;anonymous&#x27; from preconnect hints. Only needed for fonts, xhr and es module loads
-   [`119543e`](https://github.com/mochajs/mocha/commit/119543e2ac1f016cff9caaf533acbd9ad3457472) Add preconnect for doubleclick domain that google analytics results in contacting
-   [`3abed9b`](https://github.com/mochajs/mocha/commit/3abed9bcf2f763b97aecc57066718a5f62bd9833) Lint netlify-headers script
-   [`4a6e095`](https://github.com/mochajs/mocha/commit/4a6e095b889c78bb70c38a0d79792e4992ba4241) Run appveyor tests on x64 platform. Might enable sharp installation
-   [`33db6b1`](https://github.com/mochajs/mocha/commit/33db6b119c471fc275d61795ba6767eea8979ebb) Use x64 node on appveyor
-   [`ae3712c`](https://github.com/mochajs/mocha/commit/ae3712cf2f6e2323faef1d3293cb38c8c62b4dc6) [ImgBot] optimizes images (#&#8203;3175)
-   [`adc67fd`](https://github.com/mochajs/mocha/commit/adc67fd741c768d8687995158632fabf41a7c1f0) Revert &quot;[ImgBot] optimizes images (#&#8203;3175)&quot;
-   [`ea96b18`](https://github.com/mochajs/mocha/commit/ea96b18249a9e1b9236fe55c2806e32f21e6d63a) add .fossaignore [ci skip]
-   [`5be22b2`](https://github.com/mochajs/mocha/commit/5be22b23480f27679fbc0d6dd21ce6e4085029c4) `options.reporterOptions` are used for progress reporter
-   [`3c4b116`](https://github.com/mochajs/mocha/commit/3c4b11650450a60c042a2ad2feaa7d293b23790f) update CHANGELOG for v4.1.0
-   [`6b9ddc6`](https://github.com/mochajs/mocha/commit/6b9ddc64e27d8700aa6d2cc8d0bb4b47b32d6768) Release v4.1.0
#### v5.0.0
-   [`c1da848`](https://github.com/mochajs/mocha/commit/c1da848baee744fedb10ff55cf3c6c738b476aef) Update README.md
-   [`5161639`](https://github.com/mochajs/mocha/commit/51616395ee584fea4ef0d71d243244bc571375ce) Fix typos
-   [`ef981a2`](https://github.com/mochajs/mocha/commit/ef981a2794e564ccb08a48deeaf0450517ad054b) Link to unexpected.js on http. Cert errors on https
-   [`3e85f89`](https://github.com/mochajs/mocha/commit/3e85f89026ccdfb874fa523641e6d3da94a57b61) Ensure consistent calculation of duration
-   [`a554adb`](https://github.com/mochajs/mocha/commit/a554adb7bd672e3118ab3f43d4258f5c39baf768) Update .travis.yml
-   [`3f314b6`](https://github.com/mochajs/mocha/commit/3f314b619174174d4f406ba610f95f4bdf652943) drop support for ie9 and ie10; closes `https://github.com/mochajs/mocha/issues/3148`
-   [`95d2fe7`](https://github.com/mochajs/mocha/commit/95d2fe7d113852fc584cda4dbb79510d4b79271c) Update karma.conf.js
-   [`dc12bd5`](https://github.com/mochajs/mocha/commit/dc12bd5ce81dfaf5dda290c5387024be7936117a) test setup for ESM support
-   [`a723b8f`](https://github.com/mochajs/mocha/commit/a723b8f8da2977b5f7620c0cdbdb299a09ee78e4) lint Markdown; closes #&#8203;3172
-   [`b2697a7`](https://github.com/mochajs/mocha/commit/b2697a7f5fca1e953474b7ba9722d9ec98363111) add --no-timeouts to docs; closes #&#8203;3137  (#&#8203;3176)
-   [`cb09e8b`](https://github.com/mochajs/mocha/commit/cb09e8bc752a4ad506dcb9c3c4def8dbd1c6622f) document Error/undefined params to the &#x27;done&#x27; callback; closes #&#8203;3134
-   [`e54370e`](https://github.com/mochajs/mocha/commit/e54370eaa4b16db96f14157fdce06272e2b4ec68) replace phantomjs with puppeteer for browser tests; closes #&#8203;3128
-   [`565726d`](https://github.com/mochajs/mocha/commit/565726d8d4d17a6dc8683c08a43cf236d720e37e) Added Netlify config file
-   [`e8b5592`](https://github.com/mochajs/mocha/commit/e8b55925d6e80e01f824c99a1fae63148a132671) Align netlify config with admin panel
-   [`ac1dd70`](https://github.com/mochajs/mocha/commit/ac1dd704bce4f68a1b4044f748790c20b34e04c2) attempt to get travis working again
-   [`5c6e99b`](https://github.com/mochajs/mocha/commit/5c6e99b50bd2a17c03a5ae6b52862bc60121bd91) update ESM tests to run against headless chrome instead of saucelabs&#x27; chrome only
-   [`c7730a6`](https://github.com/mochajs/mocha/commit/c7730a623fd7398b968b0a3f00ad9574f31715af) Drop TextMate integration inside mocha closes `https://github.com/mochajs/mocha/issues/3118`
-   [`0a3e32b`](https://github.com/mochajs/mocha/commit/0a3e32b81b3ca65c6795cce04fc9d9a8ad9f7a1c) Rewrite Makefile using NPS Scripts. Closes #&#8203;2352
-   [`7d8abe0`](https://github.com/mochajs/mocha/commit/7d8abe0168f74bd4551a73965d2f7ff42015203e) fix id and class definition
-   [`50aec7a`](https://github.com/mochajs/mocha/commit/50aec7a249c7b2a28e2fdc18058829f48e6ee6d6) Add ability to pass in test files to be ran before positional files via --file (#&#8203;3190)
-   [`401997f`](https://github.com/mochajs/mocha/commit/401997f44dc54177d1f2dc74954be29df5e29d1d) update package-lock.json
-   [`f8a1d2a`](https://github.com/mochajs/mocha/commit/f8a1d2a388f1a7fb25313703ee128f3cc7567656) docs(index): add missing doc link (#&#8203;3203); closes #&#8203;3135
-   [`dc58252`](https://github.com/mochajs/mocha/commit/dc5825291be779122bea31fbf46593859eed638e) prep changelog for v5.0.0 [ci skip]
-   [`a7267b4`](https://github.com/mochajs/mocha/commit/a7267b4b49c423abe0924e865597caa1750416c6) remove more references to make and Makefile
-   [`9f61c04`](https://github.com/mochajs/mocha/commit/9f61c04db6f880acd9ca0dc2ca629e996fb3ab8d) finalize v5.0.0 CHANGELOG [ci skip]
-   [`cc4a818`](https://github.com/mochajs/mocha/commit/cc4a8183ae63974297d74442a9787bcb8c78fd28) Release v5.0.0
#### v5.0.1
-   [`c0ac1b9`](https://github.com/mochajs/mocha/commit/c0ac1b96a5856c9ae6a4fdd028f1bb89593f723a) fix travis &quot;before script&quot; script
-   [`2fe2d01`](https://github.com/mochajs/mocha/commit/2fe2d0116e80f37956fcf799c96276ffb8dddab5) Revert &quot;fix travis &quot;before script&quot; script&quot;
-   [`bca57f4`](https://github.com/mochajs/mocha/commit/bca57f438037b7ce2906b4b8f7ab4b9fba5d8102) clarify docs on html, xunit and 3p reporters; closes #&#8203;1906
-   [`2e7e4c0`](https://github.com/mochajs/mocha/commit/2e7e4c0c576996b87ca5a3bf226953bfa978d97a) rename &quot;common-mistake&quot; label to &quot;faq&quot;
-   [`14fc030`](https://github.com/mochajs/mocha/commit/14fc03090413b038672ca80fd9cbbfb0ccfc0826) Add all supported wallaby editors
-   [`f687d2b`](https://github.com/mochajs/mocha/commit/f687d2b0fb2e04b9ec9edfdfe58ce3ea513de369) update docs for the glob
-   [`cd74322`](https://github.com/mochajs/mocha/commit/cd743228f0999ebfe8f88f224d6d61bc063de8ed) Slight copy update on docs for test directory
-   [`b57f623`](https://github.com/mochajs/mocha/commit/b57f6234b75a1b25e0244ad9d04c4451414ee321) fix: When using --delay, .only() no longer works. Issue  #&#8203;1838
-   [`3509029`](https://github.com/mochajs/mocha/commit/3509029e5da38daca0d650094117600b6617a862) update .gitignore to only ignore root mocha.js [ci skip]
-   [`d975a6a`](https://github.com/mochajs/mocha/commit/d975a6a8455edb07477dc37a427c268aa59713ff) fix memory leak when run in v8; closes #&#8203;3119
-   [`b7377b3`](https://github.com/mochajs/mocha/commit/b7377b380202d2c0d5634dcb89dc50ea69961fb3) rename help-wanted to &quot;help wanted&quot; in stale.yml
-   [`412cf27`](https://github.com/mochajs/mocha/commit/412cf278784d56b04dc165f88e8fb7999f437958) [Update] license year
-   [`44aae9f`](https://github.com/mochajs/mocha/commit/44aae9f66db2efca550e5c9ac0dedaeac52d7e9e) add working wallaby config
-   [`70027b6`](https://github.com/mochajs/mocha/commit/70027b60da7f409a40ea267e207aceac1ec1d286) update changelog for v5.0.1 [ci skip]
-   [`09ce746`](https://github.com/mochajs/mocha/commit/09ce746aa925d35317f2624fd36c77a31bb68e24) Release v5.0.1
-   [`73d55ac`](https://github.com/mochajs/mocha/commit/73d55ac4bc2d1f10121e6d37e62f2bff7520f166) fix typos in changelog [ci skip]
-   [`c4ef568`](https://github.com/mochajs/mocha/commit/c4ef5687fa67ab97642a66ec25e05139e2d333ce) fix PR url
#### v5.0.2
-   [`f71f347`](https://github.com/mochajs/mocha/commit/f71f3472d1049737ce0e2d2131753b468d45c66a) rename wallaby.js -&gt; .wallaby.js
-   [`ec8901a`](https://github.com/mochajs/mocha/commit/ec8901a23c5194b6f7e6eee9c2568e5020c944ce) remove unused functionality in utils module
-   [`3537061`](https://github.com/mochajs/mocha/commit/3537061613886f9d37c0889d16f64dbdaf1583db) Update to correctly licensed browser-stdout version
-   [`2c720a3`](https://github.com/mochajs/mocha/commit/2c720a35000da0fecf11ef65c20ca4292c226ad7) do not eat exceptions thrown asynchronously from passed tests; closes #&#8203;3226
-   [`5078fc5`](https://github.com/mochajs/mocha/commit/5078fc5325bf7bd02b6cf448792cd1584e052b73) persist paths in stack trace which have cwd as infix
-   [`3792bef`](https://github.com/mochajs/mocha/commit/3792bef67b59add3b6d188e53f4d324e1488f159) add opencollective header image to assets/
-   [`afcd08f`](https://github.com/mochajs/mocha/commit/afcd08f1fb6782d7d4f7d4d935250279f94d728a) add MAINTAINERS.md to .fossaignore [ci skip]
-   [`0542c40`](https://github.com/mochajs/mocha/commit/0542c407fcc08be3a3e293d5df943f22d292e304) update README.md; closes #&#8203;3191 [ci skip]
-   [`6a796cb`](https://github.com/mochajs/mocha/commit/6a796cbbcd6c9f805e482c424327c82ed0398dbf) prepare CHANGELOG for v5.0.2 [ci skip]
-   [`ff1bd9e`](https://github.com/mochajs/mocha/commit/ff1bd9eaa491a29d67fa6742766464efeb82ac29) update package-lock.json
-   [`f2ee53c`](https://github.com/mochajs/mocha/commit/f2ee53c5ae4583b8117b842ffdbce6ed7387bcaf) Release v5.0.2
#### v5.0.3
-   [`bdcb3c3`](https://github.com/mochajs/mocha/commit/bdcb3c371b2261101609b8c5feb4c6eb539223fb) exposes generateDiff function from base reporter
-   [`660bccc`](https://github.com/mochajs/mocha/commit/660bcccdb70282cd160c2e18d750fc1dbe2f6a34) adds unit tests covering Base.generateDiff
-   [`8df5727`](https://github.com/mochajs/mocha/commit/8df5727478a1a9294045ace7d67c4d192ee5dda0) Tidies up code after review
-   [`aaaa5ab`](https://github.com/mochajs/mocha/commit/aaaa5abdd72e6d9db446c3c0d414947241ce6042) fix: ReDoS vuln in mocha@&#8203;5.0.2 › diff@&#8203;3.3.1 (#&#8203;3266)
-   [`70d9262`](https://github.com/mochajs/mocha/commit/70d9262d0f13906734e87e33f99afe3f4d61dff8) update CHANGELOG.md for v5.0.3 [ci skip]
-   [`da6e5c9`](https://github.com/mochajs/mocha/commit/da6e5c967af4284c48ebd35adebdf5c76d1becd1) Release v5.0.3
#### v5.0.4
-   [`eb09421`](https://github.com/mochajs/mocha/commit/eb094216bc022efd0557316b6615bda392613443) restore removed methods which still used
-   [`868830a`](https://github.com/mochajs/mocha/commit/868830ae4355fa2dbe6184431ddddc8a84bfecdd) update CHANGELOG.md for v5.0.4 [ci skip]
-   [`851ad29`](https://github.com/mochajs/mocha/commit/851ad29309b16878ad7c755158db263337cc4995) Release v5.0.4
#### v5.0.5
-   [`aa592f4`](https://github.com/mochajs/mocha/commit/aa592f45bf3895ba38ff975d809b4a0e23d289ad) update package-lock.json
-   [`85cb5c1`](https://github.com/mochajs/mocha/commit/85cb5c1bf85ee6602d75460fe299a4ea9848298b) add .vscode/ to .gitignore
-   [`3d09381`](https://github.com/mochajs/mocha/commit/3d09381290530108b8734f0aeaf9bcf35eded55f) add Karma &quot;ChromeDebug&quot; custom launcher for VSCode [ci skip]
-   [`e19e879`](https://github.com/mochajs/mocha/commit/e19e879ef412f5d6dc3214c3a154c384b04e6403) ensure lib/mocha.js is not ignored by ESLint
-   [`86af6bb`](https://github.com/mochajs/mocha/commit/86af6bb0349fb7522e9a062a9d06c7fc020971c0) fix my carelessness in e19e879
-   [`d76f490`](https://github.com/mochajs/mocha/commit/d76f490fe2f4b827712a0f8874e9cc702f507db4) chore(ci): Remove PHANTOMJS_CDNURL, nit
-   [`27af2cf`](https://github.com/mochajs/mocha/commit/27af2cf158eb9bdcf57037555bbe79cde41afccd) fix(changelog): update links to some PRs
-   [`39df783`](https://github.com/mochajs/mocha/commit/39df7838d1d8e67e8972f1c6558acd62692a3aac) docs: Fix typo in an emoji
-   [`0060884`](https://github.com/mochajs/mocha/commit/0060884cfab435ab07480c885aeb34643cbcf79b) keep hierarchy for skipped suites w/o a callback
-   [`6383916`](https://github.com/mochajs/mocha/commit/638391684a5a07a9868bb102c01a81f84434fcc1) fix to bail option works properly with hooks (#&#8203;3278)
-   [`ab84f02`](https://github.com/mochajs/mocha/commit/ab84f02e1ab0bdf11d4201a2a5acb131053f6695) chore(docs): rewording pending tests
-   [`2c19503`](https://github.com/mochajs/mocha/commit/2c19503e4a5df40ea811ce436328ab0b56949e2d) Fixed linting
-   [`19b764d`](https://github.com/mochajs/mocha/commit/19b764dcb19a27ed410067373411d840042d815d) Addressed feedback
-   [`f4275b6`](https://github.com/mochajs/mocha/commit/f4275b67c0c4e8ac863fe75b5d1bf4a78ce8cda9) extract checking AMD bundle as own test
-   [`19104e3`](https://github.com/mochajs/mocha/commit/19104e3cef7a7e8ba5c8be5b3b7cde924b8428e4) fix debug msg in Runnable#slow; closes #&#8203;2952
-   [`424ef84`](https://github.com/mochajs/mocha/commit/424ef84dbaf6f6a267102d48ef0750e939e9ddd8) increase default timeout for browser unit tests
-   [`3633fa0`](https://github.com/mochajs/mocha/commit/3633fa0061064bda98bfd6a10a6f1c5d518b87f7) append filepath to &quot;timeout exceeded&quot; exception; closes #&#8203;627- all `Runnable`s *should* now have a `file` property- filepath is appended to the `Error` message in parens- DRY-style refactors
-   [`c580294`](https://github.com/mochajs/mocha/commit/c580294893e1bf2f9e51adafd73e6cac71690d19) remove default js in &quot;--watch-extensions&quot; option; closes #&#8203;3275

</details>