### PR TITLE
chore(deps): update dependency url-loader to ^1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22724,16 +22724,34 @@
       "dev": true
     },
     "url-loader": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
-      "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.0.1.tgz",
+      "integrity": "sha512-rAonpHy7231fmweBKUFe0bYnlGDty77E+fm53NZdij7j/YOpyGzc7ttqG1nAXl3aRs0k41o0PC3TvGXQiw2Zvw==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
-        "mime": "1.4.1",
-        "schema-utils": "0.3.0"
+        "mime": "2.2.2",
+        "schema-utils": "0.4.5"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
@@ -22743,6 +22761,22 @@
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
             "json5": "0.5.1"
+          }
+        },
+        "mime": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.2.tgz",
+          "integrity": "sha512-A7PDg4s48MkqFEcYg2b069m3DXOEq7hx+9q9rIFrSSYfzsh35GX+LOVMQ8Au0ko7d8bSQCIAuzkjp0vCtwENlQ==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+          "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.0",
     "surge": "^0.20.0",
-    "url-loader": "^0.6.0",
+    "url-loader": "^1.0.0",
     "webpack": "^1.13.2",
     "webpack-cli": "^2.0.13",
     "webpack-dev-server": "^3.0.0",


### PR DESCRIPTION
This Pull Request updates dependency [url-loader](https://github.com/webpack-contrib/url-loader) from `^0.6.0` to `^1.0.0`



<details>
<summary>Release Notes</summary>

### [`v1.0.0`](https://github.com/webpack-contrib/url-loader/blob/master/CHANGELOG.md#&#8203;100httpsgithubcomwebpack-contriburl-loadercomparev100-beta0v100-2018-03-03)

##### Bug Fixes

* **index:** use `Buffer.from` instead of deprecated `new Buffer` ([#&#8203;113](`https://github.com/webpack-contrib/url-loader/issues/113`)) ([457618b](https://github.com/webpack-contrib/url-loader/commit/457618b))

---

### [`v1.0.1`](https://github.com/webpack-contrib/url-loader/blob/master/CHANGELOG.md#&#8203;101httpsgithubcomwebpack-contriburl-loadercomparev100v101-2018-03-03)

##### Bug Fixes

* **index:** revert to CJS exports (`module.exports`) ([#&#8203;116](`https://github.com/webpack-contrib/url-loader/issues/116`)) ([7b60cc2](https://github.com/webpack-contrib/url-loader/commit/7b60cc2))

---

</details>


<details>
<summary>Commits</summary>

#### v1.0.0
-   [`5aeba3e`](https://github.com/webpack-contrib/url-loader/commit/5aeba3e7af13a31b530aa133daab45ae6fd84fe1) chore: Update to defaults rc.1
-   [`4a62cd5`](https://github.com/webpack-contrib/url-loader/commit/4a62cd52a8269343ef8924b90d5eaa714a3f70f6) ci(circle): Generate checksum from lock file
-   [`b4be0c8`](https://github.com/webpack-contrib/url-loader/commit/b4be0c8fa219864dc9bb8d81b6cfcc4fda73079f) ci(circle): Fix rebuild issues
-   [`457618b`](https://github.com/webpack-contrib/url-loader/commit/457618b21310091216fbc9dcfd85c4cfc4541e5d) fix(index): use `Buffer.from` instead of deprecated `new Buffer` (#&#8203;113)
-   [`0390cdb`](https://github.com/webpack-contrib/url-loader/commit/0390cdbcad0359d5bb400b6f312afd7ca042a5c2) test: standardize (&#x60;@&#8203;webpack-contrib/test-utils&#x60;) (#&#8203;114)
-   [`0eeaaa9`](https://github.com/webpack-contrib/url-loader/commit/0eeaaa93d574b98ba405c17947a3f0ffbea5583b) chore(release): 1.0.0
#### v1.0.1
-   [`18555fa`](https://github.com/webpack-contrib/url-loader/commit/18555fa9441b5a31d6c79e1c7f155f45a5944bb2) docs(README): add missing badges (#&#8203;117)
-   [`7b60cc2`](https://github.com/webpack-contrib/url-loader/commit/7b60cc20364cb5c7ae81b24d033df6a0b27d42b0) fix(index): revert to CJS exports (`module.exports`) (#&#8203;116)
-   [`08135bc`](https://github.com/webpack-contrib/url-loader/commit/08135bcee2b187124016f9edbbe6f0f35ce2cb54) chore(release): 1.0.1

</details>