### PR TITLE
chore(deps): update dependency expect to ^22.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10012,18 +10012,28 @@
       }
     },
     "expect": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-1.20.2.tgz",
-      "integrity": "sha1-1Fj+TFYAQDa64yMkFqP2Nh8E+WU=",
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+      "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "has": "1.0.1",
-        "is-equal": "1.5.5",
-        "is-regex": "1.0.4",
-        "object-inspect": "1.5.0",
-        "object-keys": "1.0.11",
-        "tmatch": "2.0.1"
+        "ansi-styles": "3.2.1",
+        "jest-diff": "22.4.3",
+        "jest-get-type": "22.4.3",
+        "jest-matcher-utils": "22.4.3",
+        "jest-message-util": "22.4.3",
+        "jest-regex-util": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
       }
     },
     "expect-jsx": {
@@ -12881,15 +12891,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
-    "is-arrow-function": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
-      "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3"
-      }
-    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -12897,12 +12898,6 @@
       "requires": {
         "binary-extensions": "1.11.0"
       }
-    },
-    "is-boolean-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
-      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -12984,25 +12979,6 @@
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
-    "is-equal": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.5.tgz",
-      "integrity": "sha1-XoXxlX4FKIMkf+s4aWWju6Ffuz0=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "is-arrow-function": "2.0.3",
-        "is-boolean-object": "1.0.0",
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-generator-function": "1.0.7",
-        "is-number-object": "1.0.3",
-        "is-regex": "1.0.4",
-        "is-string": "1.0.4",
-        "is-symbol": "1.0.1",
-        "object.entries": "1.0.4"
-      }
-    },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
@@ -13036,12 +13012,6 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
-    },
-    "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
-      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
@@ -13077,12 +13047,6 @@
       "requires": {
         "kind-of": "3.2.2"
       }
-    },
-    "is-number-object": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
-      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
@@ -13243,12 +13207,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
@@ -13507,6 +13465,165 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
       "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
+      "dev": true
+    },
+    "jest-diff": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.2",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
+    },
+    "jest-matcher-utils": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+      "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.2",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+      "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.42",
+        "chalk": "2.3.2",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-regex-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+      "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
       "dev": true
     },
     "jquery": {
@@ -17504,12 +17621,6 @@
         }
       }
     },
-    "object-inspect": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
-      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
-      "dev": true
-    },
     "object-is": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
@@ -19064,6 +19175,33 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
     },
     "private": {
       "version": "0.1.8",
@@ -21023,6 +21161,12 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
+    "stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "dev": true
+    },
     "standard": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/standard/-/standard-11.0.1.tgz",
@@ -22274,12 +22418,6 @@
       "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
       "dev": true,
       "optional": true
-    },
-    "tmatch": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
-      "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.31",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-standard": "^3.0.0",
-    "expect": "^1.20.2",
+    "expect": "^22.0.0",
     "expect-jsx": "^5.0.0",
     "fetch": "^1.1.0",
     "fetch-mock": "6.3.0",


### PR DESCRIPTION
This Pull Request updates dependency [expect](https://github.com/facebook/jest) from `^1.20.2` to `^22.0.0`



<details>
<summary>Release Notes</summary>

### [`v21.0.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2100)

* Add --changedFilesWithAncestor
  ([#&#8203;4070](`https://github.com/facebook/jest/pull/4070`))
* Add --findRelatedFiles ([#&#8203;4131](`https://github.com/facebook/jest/pull/4131`))
* Add --onlyChanged tests ([#&#8203;3977](`https://github.com/facebook/jest/pull/3977`))
* Add `contextLines` option to jest-diff
  ([#&#8203;4152](`https://github.com/facebook/jest/pull/4152`))
* Add alternative serialize API for pretty-format plugins
  ([#&#8203;4114](`https://github.com/facebook/jest/pull/4114`))
* Add displayName to MPR ([#&#8203;4327](`https://github.com/facebook/jest/pull/4327`))
* Add displayName to TestResult
  ([#&#8203;4408](`https://github.com/facebook/jest/pull/4408`))
* Add es5 build of pretty-format
  ([#&#8203;4075](`https://github.com/facebook/jest/pull/4075`))
* Add extra info to no tests for changed files message
  ([#&#8203;4188](`https://github.com/facebook/jest/pull/4188`))
* Add fake chalk in browser builds in order to support IE10
  ([#&#8203;4367](`https://github.com/facebook/jest/pull/4367`))
* Add jest.requireActual ([#&#8203;4260](`https://github.com/facebook/jest/pull/4260`))
* Add maxWorkers to globalConfig
  ([#&#8203;4005](`https://github.com/facebook/jest/pull/4005`))
* Add skipped tests support for jest-editor-support
  ([#&#8203;4346](`https://github.com/facebook/jest/pull/4346`))
* Add source map support for better debugging experience
  ([#&#8203;3738](`https://github.com/facebook/jest/pull/3738`))
* Add support for Error objects in toMatchObject
  ([#&#8203;4339](`https://github.com/facebook/jest/pull/4339`))
* Add support for Immutable.Record in pretty-format
  ([#&#8203;3678](`https://github.com/facebook/jest/pull/3678`))
* Add tests for extract_requires on export types
  ([#&#8203;4080](`https://github.com/facebook/jest/pull/4080`))
* Add that toMatchObject can match arrays
  ([#&#8203;3994](`https://github.com/facebook/jest/pull/3994`))
* Add watchPathIgnorePatterns to exclude paths to trigger test re-run in watch
  mode ([#&#8203;4331](`https://github.com/facebook/jest/pull/4331`))
* Adding ancestorTitles property to JSON test output
  ([#&#8203;4293](`https://github.com/facebook/jest/pull/4293`))
* Allow custom resolver to be used with[out] moduleNameMapper
  ([#&#8203;4174](`https://github.com/facebook/jest/pull/4174`))
* Avoid parsing `.require(…)` method calls
  ([#&#8203;3777](`https://github.com/facebook/jest/pull/3777`))
* Avoid unnecessary function declarations and call in pretty-format
  ([#&#8203;3962](`https://github.com/facebook/jest/pull/3962`))
* Avoid writing to stdout in default reporter if --json is enabled. Fixes #&#8203;3941
  ([#&#8203;3945](`https://github.com/facebook/jest/pull/3945`))
* Better error handling for --config
  ([#&#8203;4230](`https://github.com/facebook/jest/pull/4230`))
* Call consistent pretty-format plugins within Jest
  ([#&#8203;3800](`https://github.com/facebook/jest/pull/3800`))
* Change babel-core to peerDependency for compatibility with Babel 7
  ([#&#8203;4162](`https://github.com/facebook/jest/pull/4162`))
* Change Promise detection code in jest-circus to support non-global Promise
  implementations ([#&#8203;4375](`https://github.com/facebook/jest/pull/4375`))
* Changed files eager loading
  ([#&#8203;3979](`https://github.com/facebook/jest/pull/3979`))
* Check whether we should output to stdout or stderr
  ([#&#8203;3953](`https://github.com/facebook/jest/pull/3953`))
* Clarify what objects toContain and toContainEqual can be used on
  ([#&#8203;4307](`https://github.com/facebook/jest/pull/4307`))
* Clean up resolve() logic. Provide useful names for variables and functions.
  Test that a directory exists before attempting to resolve files within it.
  ([#&#8203;4325](`https://github.com/facebook/jest/pull/4325`))
* cleanupStackTrace ([#&#8203;3696](`https://github.com/facebook/jest/pull/3696`))
* compare objects with Symbol keys
  ([#&#8203;3437](`https://github.com/facebook/jest/pull/3437`))
* Complain if expect is passed multiple arguments
  ([#&#8203;4237](`https://github.com/facebook/jest/pull/4237`))
* Completes nodeCrawl with empty roots
  ([#&#8203;3776](`https://github.com/facebook/jest/pull/3776`))
* Consistent naming of files
  ([#&#8203;3798](`https://github.com/facebook/jest/pull/3798`))
* Convert code base to ESM import
  ([#&#8203;3778](`https://github.com/facebook/jest/pull/3778`))
* Correct summary message for flag --findRelatedTests.
  ([#&#8203;4309](`https://github.com/facebook/jest/pull/4309`))
* Coverage thresholds can be set up for individual files
  ([#&#8203;4185](`https://github.com/facebook/jest/pull/4185`))
* custom reporter error handling
  ([#&#8203;4051](`https://github.com/facebook/jest/pull/4051`))
* Define separate type for pretty-format plugin Options
  ([#&#8203;3802](`https://github.com/facebook/jest/pull/3802`))
* Delete confusing async keyword
  ([#&#8203;3679](`https://github.com/facebook/jest/pull/3679`))
* Delete redundant branch in ReactElement and HTMLElement plugins
  ([#&#8203;3731](`https://github.com/facebook/jest/pull/3731`))
* Don't format node assert errors when there's no 'assert' module
  ([#&#8203;4376](`https://github.com/facebook/jest/pull/4376`))
* Don't print test summary in --silent
  ([#&#8203;4106](`https://github.com/facebook/jest/pull/4106`))
* Don't try to build ghost packages
  ([#&#8203;3934](`https://github.com/facebook/jest/pull/3934`))
* Escape double quotes in attribute values in HTMLElement plugin
  ([#&#8203;3797](`https://github.com/facebook/jest/pull/3797`))
* Explain how to clear the cache
  ([#&#8203;4232](`https://github.com/facebook/jest/pull/4232`))
* Factor out common code for collections in pretty-format
  ([#&#8203;4184](`https://github.com/facebook/jest/pull/4184`))
* Factor out common code for markup in React plugins
  ([#&#8203;4171](`https://github.com/facebook/jest/pull/4171`))
* Feature/internal resolve ([#&#8203;4315](`https://github.com/facebook/jest/pull/4315`))
* Fix --logHeapUsage ([#&#8203;4176](`https://github.com/facebook/jest/pull/4176`))
* Fix --showConfig to show all project configs
  ([#&#8203;4078](`https://github.com/facebook/jest/pull/4078`))
* Fix --watchAll ([#&#8203;4254](`https://github.com/facebook/jest/pull/4254`))
* Fix bug when setTimeout is mocked
  ([#&#8203;3769](`https://github.com/facebook/jest/pull/3769`))
* Fix changedFilesWithAncestor
  ([#&#8203;4193](`https://github.com/facebook/jest/pull/4193`))
* Fix colors for expected/stored snapshot message
  ([#&#8203;3702](`https://github.com/facebook/jest/pull/3702`))
* Fix concurrent test failure
  ([#&#8203;4159](`https://github.com/facebook/jest/pull/4159`))
* Fix for 4286: Compare Maps and Sets by value rather than order
  ([#&#8203;4303](`https://github.com/facebook/jest/pull/4303`))
* fix forceExit ([#&#8203;4105](`https://github.com/facebook/jest/pull/4105`))
* Fix grammar in React Native docs
  ([#&#8203;3838](`https://github.com/facebook/jest/pull/3838`))
* Fix inconsistent name of complex values in pretty-format
  ([#&#8203;4001](`https://github.com/facebook/jest/pull/4001`))
* Fix issue mocking bound method
  ([#&#8203;3805](`https://github.com/facebook/jest/pull/3805`))
* Fix jest-circus ([#&#8203;4290](`https://github.com/facebook/jest/pull/4290`))
* Fix lint warning in master
  ([#&#8203;4132](`https://github.com/facebook/jest/pull/4132`))
* Fix linting ([#&#8203;3946](`https://github.com/facebook/jest/pull/3946`))
* fix merge conflict ([#&#8203;4144](`https://github.com/facebook/jest/pull/4144`))
* Fix minor typo ([#&#8203;3729](`https://github.com/facebook/jest/pull/3729`))
* fix missing console.log messages
  ([#&#8203;3895](`https://github.com/facebook/jest/pull/3895`))
* fix mock return value ([#&#8203;3933](`https://github.com/facebook/jest/pull/3933`))
* Fix mocking for modules with folders on windows
  ([#&#8203;4238](`https://github.com/facebook/jest/pull/4238`))
* Fix NODE_PATH resolving for relative paths
  ([#&#8203;3616](`https://github.com/facebook/jest/pull/3616`))
* Fix options.moduleNameMapper override order with preset
  ([#&#8203;3565](`https://github.com/facebook/jest/pull/3565`)
  ([#&#8203;3689](`https://github.com/facebook/jest/pull/3689`))
* Fix React PropTypes warning in tests for Immutable plugin
  ([#&#8203;4412](`https://github.com/facebook/jest/pull/4412`))
* Fix regression in mockReturnValueOnce
  ([#&#8203;3857](`https://github.com/facebook/jest/pull/3857`))
* Fix sample code of mock class constructors
  ([#&#8203;4115](`https://github.com/facebook/jest/pull/4115`))
* Fix setup-test-framework-test
  ([#&#8203;3773](`https://github.com/facebook/jest/pull/3773`))
* fix typescript jest test crash
  ([#&#8203;4363](`https://github.com/facebook/jest/pull/4363`))
* Fix watch mode ([#&#8203;4084](`https://github.com/facebook/jest/pull/4084`))
* Fix Watchman on windows ([#&#8203;4018](`https://github.com/facebook/jest/pull/4018`))
* Fix(babel): Handle ignored files in babel v7
  ([#&#8203;4393](`https://github.com/facebook/jest/pull/4393`))
* Fix(babel): Support upcoming beta
  ([#&#8203;4403](`https://github.com/facebook/jest/pull/4403`))
* Fixed object matcher ([#&#8203;3799](`https://github.com/facebook/jest/pull/3799`))
* Fixes #&#8203;3820 use extractExpectedAssertionsErrors in jasmine setup
* Flow upgrade ([#&#8203;4355](`https://github.com/facebook/jest/pull/4355`))
* Force message in matchers to always be a function
  ([#&#8203;3972](`https://github.com/facebook/jest/pull/3972`))
* Format `describe` and use `test` instead of `it` alias
  ([#&#8203;3792](`https://github.com/facebook/jest/pull/3792`))
* global_config.js for multi-project runner
  ([#&#8203;4023](`https://github.com/facebook/jest/pull/4023`))
* Handle async errors ([#&#8203;4016](`https://github.com/facebook/jest/pull/4016`))
* Hard-fail if hasteImpl is throwing an error during initialization.
  ([#&#8203;3812](`https://github.com/facebook/jest/pull/3812`))
* Ignore import type for extract_requires
  ([#&#8203;4079](`https://github.com/facebook/jest/pull/4079`))
* Ignore indentation of data structures in jest-diff
  ([#&#8203;3429](`https://github.com/facebook/jest/pull/3429`))
* Implement 'jest.requireMock'
  ([#&#8203;4292](`https://github.com/facebook/jest/pull/4292`))
* Improve Jest phabricator plugin
  ([#&#8203;4195](`https://github.com/facebook/jest/pull/4195`))
* Improve Seq and remove newline from non-min empty in Immutable plugin
  ([#&#8203;4241](`https://github.com/facebook/jest/pull/4241`))
* Improved the jest reporter with snapshot info per test.
  ([#&#8203;3660](`https://github.com/facebook/jest/pull/3660`))
* Include fullName in formattedAssertion
  ([#&#8203;4273](`https://github.com/facebook/jest/pull/4273`))
* Integrated with Yarn workspaces
  ([#&#8203;3906](`https://github.com/facebook/jest/pull/3906`))
* jest --all ([#&#8203;4020](`https://github.com/facebook/jest/pull/4020`))
* jest-circus test failures
  ([#&#8203;3770](`https://github.com/facebook/jest/pull/3770`))
* jest-circus Timeouts ([#&#8203;3760](`https://github.com/facebook/jest/pull/3760`))
* jest-haste-map: add test case for broken handling of ignore pattern
  ([#&#8203;4047](`https://github.com/facebook/jest/pull/4047`))
* jest-haste-map: add test+fix for broken platform module support
  ([#&#8203;3885](`https://github.com/facebook/jest/pull/3885`))
* jest-haste-map: deprecate functional ignorePattern and use it in cache key
  ([#&#8203;4063](`https://github.com/facebook/jest/pull/4063`))
* jest-haste-map: mock 'fs' with more idiomatic jest.mock()
  ([#&#8203;4046](`https://github.com/facebook/jest/pull/4046`))
* jest-haste-map: only file IO errors should be silently ignored
  ([#&#8203;3816](`https://github.com/facebook/jest/pull/3816`))
* jest-haste-map: throw when trying to get a duplicated module
  ([#&#8203;3976](`https://github.com/facebook/jest/pull/3976`))
* jest-haste-map: watchman crawler: normalize paths
  ([#&#8203;3887](`https://github.com/facebook/jest/pull/3887`))
* jest-runtime: atomic cache write, and check validity of data
  ([#&#8203;4088](`https://github.com/facebook/jest/pull/4088`))
* Join lines with newline in jest-diff
  ([#&#8203;4314](`https://github.com/facebook/jest/pull/4314`))
* Keep ARGV only in CLI files
  ([#&#8203;4012](`https://github.com/facebook/jest/pull/4012`))
* let transformers adjust cache key based on mapCoverage
  ([#&#8203;4187](`https://github.com/facebook/jest/pull/4187`))
* Lift requires ([#&#8203;3780](`https://github.com/facebook/jest/pull/3780`))
* Log stack when reporting errors in jest-runtime
  ([#&#8203;3833](`https://github.com/facebook/jest/pull/3833`))
* Make --listTests return a new line separated list when not using --json
  ([#&#8203;4229](`https://github.com/facebook/jest/pull/4229`))
* Make build script printing small-terminals-friendly
  ([#&#8203;3892](`https://github.com/facebook/jest/pull/3892`))
* Make error messages more explicit for toBeCalledWith assertions
  ([#&#8203;3913](`https://github.com/facebook/jest/pull/3913`))
* Make jest-matcher-utils use ESM exports
  ([#&#8203;4342](`https://github.com/facebook/jest/pull/4342`))
* Make jest-runner a standalone package.
  ([#&#8203;4236](`https://github.com/facebook/jest/pull/4236`))
* Make Jest’s Test Runner configurable.
  ([#&#8203;4240](`https://github.com/facebook/jest/pull/4240`))
* Make listTests always print to console.log
  ([#&#8203;4391](`https://github.com/facebook/jest/pull/4391`))
* Make providesModuleNodeModules ignore nested node_modules directories
* Make sure function mocks match original arity
  ([#&#8203;4170](`https://github.com/facebook/jest/pull/4170`))
* Make sure runAllTimers also clears all ticks
  ([#&#8203;3915](`https://github.com/facebook/jest/pull/3915`))
* Make toBe matcher error message more helpful for objects and arrays
  ([#&#8203;4277](`https://github.com/facebook/jest/pull/4277`))
* Make useRealTimers play well with timers: fake
  ([#&#8203;3858](`https://github.com/facebook/jest/pull/3858`))
* Move getType from jest-matcher-utils to separate package
  ([#&#8203;3559](`https://github.com/facebook/jest/pull/3559`))
* Multiroot jest-change-files
  ([#&#8203;3969](`https://github.com/facebook/jest/pull/3969`))
* Output created snapshot when using --ci option
  ([#&#8203;3693](`https://github.com/facebook/jest/pull/3693`))
* Point out you can use matchers in .toMatchObject
  ([#&#8203;3796](`https://github.com/facebook/jest/pull/3796`))
* Prevent babelrc package import failure on relative current path
  ([#&#8203;3723](`https://github.com/facebook/jest/pull/3723`))
* Print RDP details for windows builds
  ([#&#8203;4017](`https://github.com/facebook/jest/pull/4017`))
* Provide better error checking for transformed content
  ([#&#8203;3807](`https://github.com/facebook/jest/pull/3807`))
* Provide printText and printComment in markup.js for HTMLElement plugin
  ([#&#8203;4344](`https://github.com/facebook/jest/pull/4344`))
* Provide regex visualization for testRegex
  ([#&#8203;3758](`https://github.com/facebook/jest/pull/3758`))
* Refactor CLI ([#&#8203;3862](`https://github.com/facebook/jest/pull/3862`))
* Refactor names and delimiters of complex values in pretty-format
  ([#&#8203;3986](`https://github.com/facebook/jest/pull/3986`))
* Replace concat(Immutable) with Immutable as item of plugins array
  ([#&#8203;4207](`https://github.com/facebook/jest/pull/4207`))
* Replace Jasmine with jest-circus
  ([#&#8203;3668](`https://github.com/facebook/jest/pull/3668`))
* Replace match with test and omit redundant String conversion
  ([#&#8203;4311](`https://github.com/facebook/jest/pull/4311`))
* Replace print with serialize in AsymmetricMatcher plugin
  ([#&#8203;4173](`https://github.com/facebook/jest/pull/4173`))
* Replace print with serialize in ConvertAnsi plugin
  ([#&#8203;4225](`https://github.com/facebook/jest/pull/4225`))
* Replace print with serialize in HTMLElement plugin
  ([#&#8203;4215](`https://github.com/facebook/jest/pull/4215`))
* Replace print with serialize in Immutable plugins
  ([#&#8203;4189](`https://github.com/facebook/jest/pull/4189`))
* Replace unchanging args with one config arg within pretty-format
  ([#&#8203;4076](`https://github.com/facebook/jest/pull/4076`))
* Return UNDEFINED for undefined type in ReactElement plugin
  ([#&#8203;4360](`https://github.com/facebook/jest/pull/4360`))
* Rewrite some read bumps in pretty-format
  ([#&#8203;4093](`https://github.com/facebook/jest/pull/4093`))
* Run update method before installing JRE on Circle
  ([#&#8203;4318](`https://github.com/facebook/jest/pull/4318`))
* Separated the snapshot summary creation from the printing to improve
  testability. ([#&#8203;4373](`https://github.com/facebook/jest/pull/4373`))
* Set coverageDirectory during normalize phase
  ([#&#8203;3966](`https://github.com/facebook/jest/pull/3966`))
* Setup custom reporters after default reporters
  ([#&#8203;4053](`https://github.com/facebook/jest/pull/4053`))
* Setup for Circle 2 ([#&#8203;4149](`https://github.com/facebook/jest/pull/4149`))
* Simplify readme ([#&#8203;3790](`https://github.com/facebook/jest/pull/3790`))
* Simplify snapshots definition
  ([#&#8203;3791](`https://github.com/facebook/jest/pull/3791`))
* skipNodeResolution config option
  ([#&#8203;3987](`https://github.com/facebook/jest/pull/3987`))
* Small fixes to toHaveProperty docs
  ([#&#8203;3878](`https://github.com/facebook/jest/pull/3878`))
* Sort attributes by name in HTMLElement plugin
  ([#&#8203;3783](`https://github.com/facebook/jest/pull/3783`))
* Specify watchPathIgnorePatterns will only be available in Jest 21+
  ([#&#8203;4398](`https://github.com/facebook/jest/pull/4398`))
* Split TestRunner off of TestScheduler
  ([#&#8203;4233](`https://github.com/facebook/jest/pull/4233`))
* Strict and explicit config resolution logic
  ([#&#8203;4122](`https://github.com/facebook/jest/pull/4122`))
* Support maxDepth option in React plugins
  ([#&#8203;4208](`https://github.com/facebook/jest/pull/4208`))
* Support SVG elements in HTMLElement plugin
  ([#&#8203;4335](`https://github.com/facebook/jest/pull/4335`))
* Test empty Immutable collections with {min: false} option
  ([#&#8203;4121](`https://github.com/facebook/jest/pull/4121`))
* test to debug travis failure in master
  ([#&#8203;4145](`https://github.com/facebook/jest/pull/4145`))
* testPathPattern message test
  ([#&#8203;4006](`https://github.com/facebook/jest/pull/4006`))
* Throw Error When Using Nested It Specs
  ([#&#8203;4039](`https://github.com/facebook/jest/pull/4039`))
* Throw when moduleNameMapper points to inexistent module
  ([#&#8203;3567](`https://github.com/facebook/jest/pull/3567`))
* Unified 'no tests found' message for non-verbose MPR
  ([#&#8203;4354](`https://github.com/facebook/jest/pull/4354`))
* Update migration guide with jest-codemods transformers
  ([#&#8203;4306](`https://github.com/facebook/jest/pull/4306`))
* Use "inputSourceMap" for coverage re-mapping.
  ([#&#8203;4009](`https://github.com/facebook/jest/pull/4009`))
* Use "verbose" no test found message when there is only one project
  ([#&#8203;4378](`https://github.com/facebook/jest/pull/4378`))
* Use babel transform to inline all requires
  ([#&#8203;4340](`https://github.com/facebook/jest/pull/4340`))
* Use eslint plugins to run prettier
  ([#&#8203;3971](`https://github.com/facebook/jest/pull/3971`))
* Use iterableEquality in spy matchers
  ([#&#8203;3651](`https://github.com/facebook/jest/pull/3651`))
* Use modern HTML5 <!DOCTYPE>
  ([#&#8203;3937](`https://github.com/facebook/jest/pull/3937`))
* Wrap `Error.captureStackTrace` in a try
  ([#&#8203;4035](`https://github.com/facebook/jest/pull/4035`))

---

### [`v21.0.2`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2102)

* Take precedence of NODE_PATH when resolving node_modules directories
  ([#&#8203;4453](`https://github.com/facebook/jest/pull/4453`))
* Fix race condition with --coverage and babel-jest identical file contents edge
  case ([#&#8203;4432](`https://github.com/facebook/jest/pull/4432`))
* Add extra parameter `--runTestsByPath`.
  ([#&#8203;4411](`https://github.com/facebook/jest/pull/4411`))
* Upgrade all outdated deps
  ([#&#8203;4425](`https://github.com/facebook/jest/pull/4425`))

---

### [`v21.1.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2110)

* (minor) Use ES module exports
  ([#&#8203;4454](`https://github.com/facebook/jest/pull/4454`))
* Allow chaining mockClear and mockReset
  ([#&#8203;4475](`https://github.com/facebook/jest/pull/4475`))
* Call jest-diff and pretty-format more precisely in toHaveProperty matcher
  ([#&#8203;4445](`https://github.com/facebook/jest/pull/4445`))
* Expose restoreAllMocks to object
  ([#&#8203;4463](`https://github.com/facebook/jest/pull/4463`))
* Fix function name cleaning when making mock fn
  ([#&#8203;4464](`https://github.com/facebook/jest/pull/4464`))
* Fix Map/Set equality checker
  ([#&#8203;4404](`https://github.com/facebook/jest/pull/4404`))
* Make FUNCTION_NAME_RESERVED_PATTERN stateless
  ([#&#8203;4466](`https://github.com/facebook/jest/pull/4466`))

---

### [`v21.2.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2120)

* 🃏 Change license from BSD+Patents to MIT.
* Allow eslint-plugin to recognize more disabled tests
  ([#&#8203;4533](`https://github.com/facebook/jest/pull/4533`))
* Add babel-plugin for object spread syntax to babel-preset-jest
  ([#&#8203;4519](`https://github.com/facebook/jest/pull/4519`))
* Display outer element and trailing newline consistently in jest-diff
  ([#&#8203;4520](`https://github.com/facebook/jest/pull/4520`))
* Do not modify stack trace of JestAssertionError
  ([#&#8203;4516](`https://github.com/facebook/jest/pull/4516`))
* Print errors after test structure in verbose mode
  ([#&#8203;4504](`https://github.com/facebook/jest/pull/4504`))
* Fix `--silent --verbose` problem
  ([#&#8203;4505](`https://github.com/facebook/jest/pull/4505`))
* Fix: Reset local state of assertions when using hasAssertions
  ([#&#8203;4498](`https://github.com/facebook/jest/pull/4498`))
* jest-resolve: Prevent default resolver failure when potential resolution
  directory does not exist ([#&#8203;4483](`https://github.com/facebook/jest/pull/4483`))

---

### [`v21.2.1`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2121)

* Fix watchAll not running tests on save
  ([#&#8203;4550](`https://github.com/facebook/jest/pull/4550`))
* Add missing escape sequences to ConvertAnsi plugin
  ([#&#8203;4544](`https://github.com/facebook/jest/pull/4544`))

---

### [`v22.0.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2200)

##### Fixes

* `[jest-resolve]` Use `module.builtinModules` as `BUILTIN_MODULES` when it
  exists
* `[jest-worker]` Remove `debug` and `inspect` flags from the arguments sent to
  the child ([#&#8203;5068](`https://github.com/facebook/jest/pull/5068`))
* `[jest-config]` Use all `--testPathPattern` and `<regexForTestFiles>` args in
  `testPathPattern` ([#&#8203;5066](`https://github.com/facebook/jest/pull/5066`))
* `[jest-cli]` Do not support `--watch` inside non-version-controlled
  environments ([#&#8203;5060](`https://github.com/facebook/jest/pull/5060`))
* `[jest-config]` Escape Windows path separator in testPathPattern CLI arguments
  ([#&#8203;5054](`https://github.com/facebook/jest/pull/5054`)
* `[jest-jasmine]` Register sourcemaps as node environment to improve
  performance with jsdom ([#&#8203;5045](`https://github.com/facebook/jest/pull/5045`))
* `[pretty-format]` Do not call toJSON recursively
  ([#&#8203;5044](`https://github.com/facebook/jest/pull/5044`))
* `[pretty-format]` Fix errors when identity-obj-proxy mocks CSS Modules
  ([#&#8203;4935](`https://github.com/facebook/jest/pull/4935`))
* `[babel-jest]` Fix support for namespaced babel version 7
  ([#&#8203;4918](`https://github.com/facebook/jest/pull/4918`))
* `[expect]` fix .toThrow for promises
  ([#&#8203;4884](`https://github.com/facebook/jest/pull/4884`))
* `[jest-docblock]` pragmas should preserve urls
  ([#&#8203;4837](`https://github.com/facebook/jest/pull/4629`))
* `[jest-cli]` Check if `npm_lifecycle_script` calls Jest directly
  ([#&#8203;4629](`https://github.com/facebook/jest/pull/4629`))
* `[jest-cli]` Fix --showConfig to show all configs
  ([#&#8203;4494](`https://github.com/facebook/jest/pull/4494`))
* `[jest-cli]` Throw if `maxWorkers` doesn't have a value
  ([#&#8203;4591](`https://github.com/facebook/jest/pull/4591`))
* `[jest-cli]` Use `fs.realpathSync.native` if available
  ([#&#8203;5031](`https://github.com/facebook/jest/pull/5031`))
* `[jest-config]` Fix `--passWithNoTests`
  ([#&#8203;4639](`https://github.com/facebook/jest/pull/4639`))
* `[jest-config]` Support `rootDir` tag in testEnvironment
  ([#&#8203;4579](`https://github.com/facebook/jest/pull/4579`))
* `[jest-editor-support]` Fix `--showConfig` to support jest 20 and jest 21
  ([#&#8203;4575](`https://github.com/facebook/jest/pull/4575`))
* `[jest-editor-support]` Fix editor support test for node 4
  ([#&#8203;4640](`https://github.com/facebook/jest/pull/4640`))
* `[jest-mock]` Support mocking constructor in `mockImplementationOnce`
  ([#&#8203;4599](`https://github.com/facebook/jest/pull/4599`))
* `[jest-runtime]` Fix manual user mocks not working with custom resolver
  ([#&#8203;4489](`https://github.com/facebook/jest/pull/4489`))
* `[jest-util]` Fix `runOnlyPendingTimers` for `setTimeout` inside
  `setImmediate` ([#&#8203;4608](`https://github.com/facebook/jest/pull/4608`))
* `[jest-message-util]` Always remove node internals from stacktraces
  ([#&#8203;4695](`https://github.com/facebook/jest/pull/4695`))
* `[jest-resolve]` changes method of determining builtin modules to include
  missing builtins ([#&#8203;4740](`https://github.com/facebook/jest/pull/4740`))
* `[pretty-format]` Prevent error in pretty-format for window in jsdom test env
  ([#&#8203;4750](`https://github.com/facebook/jest/pull/4750`))
* `[jest-resolve]` Preserve module identity for symlinks
  ([#&#8203;4761](`https://github.com/facebook/jest/pull/4761`))
* `[jest-config]` Include error message for `preset` json
  ([#&#8203;4766](`https://github.com/facebook/jest/pull/4766`))
* `[pretty-format]` Throw `PrettyFormatPluginError` if a plugin halts with an
  exception ([#&#8203;4787](`https://github.com/facebook/jest/pull/4787`))
* `[expect]` Keep the stack trace unchanged when `PrettyFormatPluginError` is
  thrown by pretty-format ([#&#8203;4787](`https://github.com/facebook/jest/pull/4787`))
* `[jest-environment-jsdom]` Fix asynchronous test will fail due to timeout
  issue. ([#&#8203;4669](`https://github.com/facebook/jest/pull/4669`))
* `[jest-cli]` Fix `--onlyChanged` path case sensitivity on Windows platform
  ([#&#8203;4730](`https://github.com/facebook/jest/pull/4730`))
* `[jest-runtime]` Use realpath to match transformers
  ([#&#8203;5000](`https://github.com/facebook/jest/pull/5000`))
* `[expect]` [**BREAKING**] Replace identity equality with Object.is in toBe
  matcher ([#&#8203;4917](`https://github.com/facebook/jest/pull/4917`))
##### Features

* `[jest-message-util]` Add codeframe to test assertion failures
  ([#&#8203;5087](`https://github.com/facebook/jest/pull/5087`))
* `[jest-config]` Add Global Setup/Teardown options
  ([#&#8203;4716](`https://github.com/facebook/jest/pull/4716`))
* `[jest-config]` Add `testEnvironmentOptions` to apply to jsdom options or node
  context. ([#&#8203;5003](`https://github.com/facebook/jest/pull/5003`))
* `[jest-jasmine2]` Update Timeout error message to `jest.timeout` and display
  current timeout value ([#&#8203;4990](`https://github.com/facebook/jest/pull/4990`))
* `[jest-runner]` Enable experimental detection of leaked contexts
  ([#&#8203;4895](`https://github.com/facebook/jest/pull/4895`))
* `[jest-cli]` Add combined coverage threshold for directories.
  ([#&#8203;4885](`https://github.com/facebook/jest/pull/4885`))
* `[jest-mock]` Add `timestamps` to mock state.
  ([#&#8203;4866](`https://github.com/facebook/jest/pull/4866`))
* `[eslint-plugin-jest]` Add `prefer-to-have-length` lint rule.
  ([#&#8203;4771](`https://github.com/facebook/jest/pull/4771`))
* `[jest-environment-jsdom]` [**BREAKING**] Upgrade to JSDOM@&#8203;11
  ([#&#8203;4770](`https://github.com/facebook/jest/pull/4770`))
* `[jest-environment-*]` [**BREAKING**] Add Async Test Environment APIs, dispose
  is now teardown ([#&#8203;4506](`https://github.com/facebook/jest/pull/4506`))
* `[jest-cli]` Add an option to clear the cache
  ([#&#8203;4430](`https://github.com/facebook/jest/pull/4430`))
* `[babel-plugin-jest-hoist]` Improve error message, that the second argument of
  `jest.mock` must be an inline function
  ([#&#8203;4593](`https://github.com/facebook/jest/pull/4593`))
* `[jest-snapshot]` [**BREAKING**] Concatenate name of test and snapshot
  ([#&#8203;4460](`https://github.com/facebook/jest/pull/4460`))
* `[jest-cli]` [**BREAKING**] Fail if no tests are found
  ([#&#8203;3672](`https://github.com/facebook/jest/pull/3672`))
* `[jest-diff]` Highlight only last of odd length leading spaces
  ([#&#8203;4558](`https://github.com/facebook/jest/pull/4558`))
* `[jest-docblock]` Add `docblock.print()`
  ([#&#8203;4517](`https://github.com/facebook/jest/pull/4517`))
* `[jest-docblock]` Add `strip`
  ([#&#8203;4571](`https://github.com/facebook/jest/pull/4571`))
* `[jest-docblock]` Preserve leading whitespace in docblock comments
  ([#&#8203;4576](`https://github.com/facebook/jest/pull/4576`))
* `[jest-docblock]` remove leading newlines from `parswWithComments().comments`
  ([#&#8203;4610](`https://github.com/facebook/jest/pull/4610`))
* `[jest-editor-support]` Add Snapshots metadata
  ([#&#8203;4570](`https://github.com/facebook/jest/pull/4570`))
* `[jest-editor-support]` Adds an 'any' to the typedef for
  `updateFileWithJestStatus`
  ([#&#8203;4636](`https://github.com/facebook/jest/pull/4636`))
* `[jest-editor-support]` Better monorepo support
  ([#&#8203;4572](`https://github.com/facebook/jest/pull/4572`))
* `[jest-environment-jsdom]` Add simple rAF polyfill in jsdom environment to
  work with React 16 ([#&#8203;4568](`https://github.com/facebook/jest/pull/4568`))
* `[jest-environment-node]` Implement node Timer api
  ([#&#8203;4622](`https://github.com/facebook/jest/pull/4622`))
* `[jest-jasmine2]` Add testPath to reporter callbacks
  ([#&#8203;4594](`https://github.com/facebook/jest/pull/4594`))
* `[jest-mock]` Added support for naming mocked functions with
  `.mockName(value)` and `.mockGetName()`
  ([#&#8203;4586](`https://github.com/facebook/jest/pull/4586`))
* `[jest-runtime]` Add `module.loaded`, and make `module.require` not enumerable
  ([#&#8203;4623](`https://github.com/facebook/jest/pull/4623`))
* `[jest-runtime]` Add `module.parent`
  ([#&#8203;4614](`https://github.com/facebook/jest/pull/4614`))
* `[jest-runtime]` Support sourcemaps in transformers
  ([#&#8203;3458](`https://github.com/facebook/jest/pull/3458`))
* `[jest-snapshot]` [**BREAKING**] Add a serializer for `jest.fn` to allow a
  snapshot of a jest mock ([#&#8203;4668](`https://github.com/facebook/jest/pull/4668`))
* `[jest-worker]` Initial version of parallel worker abstraction, say hello!
  ([#&#8203;4497](`https://github.com/facebook/jest/pull/4497`))
* `[jest-jasmine2]` Add `testLocationInResults` flag to add location information
  per spec to test results ([#&#8203;4782](`https://github.com/facebook/jest/pull/4782`))
* `[jest-environment-jsdom]` Update JSOM to 11.4, which includes built-in
  support for `requestAnimationFrame`
  ([#&#8203;4919](`https://github.com/facebook/jest/pull/4919`))
* `[jest-cli]` Hide watch usage output when running on non-interactive
  environments ([#&#8203;4958](`https://github.com/facebook/jest/pull/4958`))
* `[jest-snapshot]` Promises support for `toThrowErrorMatchingSnapshot`
  ([#&#8203;4946](`https://github.com/facebook/jest/pull/4946`))
* `[jest-cli]` Explain which snapshots are obsolete
  ([#&#8203;5005](`https://github.com/facebook/jest/pull/5005`))
##### Chore & Maintenance

* `[docs]` Add guide of using with puppeteer
  ([#&#8203;5093](`https://github.com/facebook/jest/pull/5093`))
* `[jest-util]` `jest-util` should not depend on `jest-mock`
  ([#&#8203;4992](`https://github.com/facebook/jest/pull/4992`))
* `[*]` [**BREAKING**] Drop support for Node.js version 4
  ([#&#8203;4769](`https://github.com/facebook/jest/pull/4769`))
* `[docs]` Wrap code comments at 80 characters
  ([#&#8203;4781](`https://github.com/facebook/jest/pull/4781`))
* `[eslint-plugin-jest]` Removed from the Jest core repo, and moved to
  https://github.com/jest-community/eslint-plugin-jest
  ([#&#8203;4867](`https://github.com/facebook/jest/pull/4867`))
* `[babel-jest]` Explicitly bump istanbul to newer versions
  ([#&#8203;4616](`https://github.com/facebook/jest/pull/4616`))
* `[expect]` Upgrade mocha and rollup for browser testing
  ([#&#8203;4642](`https://github.com/facebook/jest/pull/4642`))
* `[docs]` Add info about `coveragePathIgnorePatterns`
  ([#&#8203;4602](`https://github.com/facebook/jest/pull/4602`))
* `[docs]` Add Vuejs series of testing with Jest
  ([#&#8203;4648](`https://github.com/facebook/jest/pull/4648`))
* `[docs]` Mention about optional `done` argument in test function
  ([#&#8203;4556](`https://github.com/facebook/jest/pull/4556`))
* `[jest-cli]` Bump node-notifier version
  ([#&#8203;4609](`https://github.com/facebook/jest/pull/4609`))
* `[jest-diff]` Simplify highlight for leading and trailing spaces
  ([#&#8203;4553](`https://github.com/facebook/jest/pull/4553`))
* `[jest-get-type]` Add support for date
  ([#&#8203;4621](`https://github.com/facebook/jest/pull/4621`))
* `[jest-matcher-utils]` Call `chalk.inverse` for trailing spaces
  ([#&#8203;4578](`https://github.com/facebook/jest/pull/4578`))
* `[jest-runtime]` Add `.advanceTimersByTime`; keep `.runTimersToTime()` as an
  alias.
* `[docs]` Include missing dependency in TestEnvironment sample code
* `[docs]` Add clarification for hook execution order
* `[docs]` Update `expect.anything()` sample code
  ([#&#8203;5007](`https://github.com/facebook/jest/pull/5007`))

---

### [`v22.0.1`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2201)

##### Fixes

* `[jest-runtime]` fix error for test files providing coverage.
  ([#&#8203;5117](`https://github.com/facebook/jest/pull/5117`))
##### Features

* `[jest-config]` Add `forceCoverageMatch` to allow collecting coverage from
  ignored files. ([#&#8203;5081](`https://github.com/facebook/jest/pull/5081`))

---

### [`v22.0.2`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203)

##### Chore & Maintenance

* `[*]` Tweaks to better support Node 4
  ([#&#8203;5134](`https://github.com/facebook/jest/pull/5134`))

---

### [`v22.0.3`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203)

##### Chore & Maintenance

* `[*]` Tweaks to better support Node 4
  ([#&#8203;5134](`https://github.com/facebook/jest/pull/5134`))

---

### [`v22.0.5`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2205)

##### Fixes

* `[jest-leak-detector]` Removed the reference to `weak`. Now, parent projects
  must install it by hand for the module to work.
* `[expect]` Fail test when the types of `stringContaining` and `stringMatching`
  matchers do not match. ([#&#8203;5069](`https://github.com/facebook/jest/pull/5069`))
* `[jest-cli]` Treat dumb terminals as noninteractive
  ([#&#8203;5237](`https://github.com/facebook/jest/pull/5237`))
* `[jest-cli]` `jest --onlyChanged --changedFilesWithAncestor` now also works
  with git. ([#&#8203;5189](`https://github.com/facebook/jest/pull/5189`))
* `[jest-config]` fix unexpected condition to avoid infinite recursion in
  Windows platform. ([#&#8203;5161](`https://github.com/facebook/jest/pull/5161`))
* `[jest-config]` Escape parentheses and other glob characters in `rootDir`
  before interpolating with `testMatch`.
  ([#&#8203;4838](`https://github.com/facebook/jest/issues/4838`))
* `[jest-regex-util]` Fix breaking change in `--testPathPattern`
  ([#&#8203;5230](`https://github.com/facebook/jest/pull/5230`))
* `[expect]` Do not override `Error` stack (with `Error.captureStackTrace`) for
  custom matchers. ([#&#8203;5162](`https://github.com/facebook/jest/pull/5162`))
* `[pretty-format]` Pretty format for DOMStringMap and NamedNodeMap
  ([#&#8203;5233](`https://github.com/facebook/jest/pull/5233`))
* `[jest-cli]` Use a better console-clearing string on Windows
  ([#&#8203;5251](`https://github.com/facebook/jest/pull/5251`))
##### Features

* `[jest-jasmine]` Allowed classes and functions as `describe` names.
  ([#&#8203;5154](`https://github.com/facebook/jest/pull/5154`))
* `[jest-jasmine2]` Support generator functions as specs.
  ([#&#8203;5166](`https://github.com/facebook/jest/pull/5166`))
* `[jest-jasmine2]` Allow `spyOn` with getters and setters.
  ([#&#8203;5107](`https://github.com/facebook/jest/pull/5107`))
* `[jest-config]` Allow configuration objects inside `projects` array
  ([#&#8203;5176](`https://github.com/facebook/jest/pull/5176`))
* `[expect]` Add support to `.toHaveProperty` matcher to accept the keyPath
  argument as an array of properties/indices.
  ([#&#8203;5220](`https://github.com/facebook/jest/pull/5220`))
* `[docs]` Add documentation for .toHaveProperty matcher to accept the keyPath
  argument as an array of properties/indices.
  ([#&#8203;5220](`https://github.com/facebook/jest/pull/5220`))
* `[jest-runner]` test environments are now passed a new `options` parameter.
  Currently this only has the `console` which is the test console that Jest will
  expose to tests. ([#&#8203;5223](`https://github.com/facebook/jest/issues/5223`))
* `[jest-environment-jsdom]` pass the `options.console` to a custom instance of
  `virtualConsole` so jsdom is using the same console as the test.
  ([#&#8203;5223](`https://github.com/facebook/jest/issues/5223`))
##### Chore & Maintenance

* `[docs]` Describe the order of execution of describe and test blocks.
  ([#&#8203;5217](`https://github.com/facebook/jest/pull/5217`),
  [#&#8203;5238](`https://github.com/facebook/jest/pull/5238`))
* `[docs]` Add a note on `moduleNameMapper` ordering.
  ([#&#8203;5249](`https://github.com/facebook/jest/pull/5249`))

---

### [`v22.0.6`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2206)

##### Fixes

* `[jest-jasmine2]` Fix memory leak in snapshot reporting
  ([#&#8203;5279](`https://github.com/facebook/jest/pull/5279`))
* `[jest-config]` Fix breaking change in `--testPathPattern`
  ([#&#8203;5269](`https://github.com/facebook/jest/pull/5269`))
* `[docs]` Document caveat with mocks, Enzyme, snapshots and React 16
  ([#&#8203;5258](`https://github.com/facebook/jest/issues/5258`))

---

### [`v22.1.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2210)

##### Features

* `[jest-cli]` Make Jest exit without an error when no tests are found in the
  case of `--lastCommit`, `--findRelatedTests`, or `--onlyChanged` options
  having been passed to the CLI
* `[jest-cli]` Add interactive snapshot mode
  ([#&#8203;3831](`https://github.com/facebook/jest/pull/3831`))
##### Fixes

* `[jest-cli]` Use `import-local` to support global Jest installations.
  ([#&#8203;5304](`https://github.com/facebook/jest/pull/5304`))
* `[jest-runner]` Fix memory leak in coverage reporting
  ([#&#8203;5289](`https://github.com/facebook/jest/pull/5289`))
* `[docs]` Update mention of the minimal version of node supported
  ([#&#8203;4947](`https://github.com/facebook/jest/issues/4947`))
* `[jest-cli]` Fix missing newline in console message
  ([#&#8203;5308](`https://github.com/facebook/jest/pull/5308`))
* `[jest-cli]` `--lastCommit` and `--changedFilesWithAncestor` now take effect
  even when `--onlyChanged` is not specified.
  ([#&#8203;5307](`https://github.com/facebook/jest/pull/5307`))
##### Chore & Maintenance

* `[filenames]` Standardize folder names under `integration-tests/`
  ([#&#8203;5298](`https://github.com/facebook/jest/pull/5298`))

---

### [`v22.2.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2220)

##### Features

* `[jest-runner]` Move test summary to after coverage report
  ([#&#8203;4512](`https://github.com/facebook/jest/pull/4512`))
* `[jest-cli]` Added `--notifyMode` to specify when to be notified.
  ([#&#8203;5125](`https://github.com/facebook/jest/pull/5125`))
* `[diff-sequences]` New package compares items in two sequences to find a
  **longest common subsequence**.
  ([#&#8203;5407](`https://github.com/facebook/jest/pull/5407`))
* `[jest-matcher-utils]` Add `comment` option to `matcherHint` function
  ([#&#8203;5437](`https://github.com/facebook/jest/pull/5437`))
* `[jest-config]` Allow lastComit and changedFilesWithAncestor via JSON config
  ([#&#8203;5476](`https://github.com/facebook/jest/pull/5476`))
* `[jest-util]` Add deletion to `process.env` as well
  ([#&#8203;5466](`https://github.com/facebook/jest/pull/5466`))
* `[jest-util]` Add case-insensitive getters/setters to `process.env`
  ([#&#8203;5465](`https://github.com/facebook/jest/pull/5465`))
* `[jest-mock]` Add util methods to create async functions.
  ([#&#8203;5318](`https://github.com/facebook/jest/pull/5318`))
##### Fixes

* `[jest-cli]` Add trailing slash when checking root folder
  ([#&#8203;5464](`https://github.com/facebook/jest/pull/5464`))
* `[jest-cli]` Hide interactive mode if there are no failed snapshot tests
  ([#&#8203;5450](`https://github.com/facebook/jest/pull/5450`))
* `[babel-jest]` Remove retainLines from babel-jest
  ([#&#8203;5439](`https://github.com/facebook/jest/pull/5439`))
* `[jest-cli]` Glob patterns ignore non-`require`-able files (e.g. `README.md`)
  ([#&#8203;5199](`https://github.com/facebook/jest/issues/5199`))
* `[jest-mock]` Add backticks support (\`\`) to `mock` a certain package via the
  `__mocks__` folder. ([#&#8203;5426](`https://github.com/facebook/jest/pull/5426`))
* `[jest-message-util]` Prevent an `ENOENT` crash when the test file contained a
  malformed source-map. ([#&#8203;5405](`https://github.com/facebook/jest/pull/5405`)).
* `[jest]` Add `import-local` to `jest` package.
  ([#&#8203;5353](`https://github.com/facebook/jest/pull/5353`))
* `[expect]` Support class instances in `.toHaveProperty()` and `.toMatchObject`
  matcher. ([#&#8203;5367](`https://github.com/facebook/jest/pull/5367`))
* `[jest-cli]` Fix npm update command for snapshot summary.
  ([#&#8203;5376](`https://github.com/facebook/jest/pull/5376`),
  [5389](`https://github.com/facebook/jest/pull/5389`/))
* `[expect]` Make `rejects` and `resolves` synchronously validate its argument.
  ([#&#8203;5364](`https://github.com/facebook/jest/pull/5364`))
* `[docs]` Add tutorial page for ES6 class mocks.
  ([#&#8203;5383](`https://github.com/facebook/jest/pull/5383`))
* `[jest-resolve]` Search required modules in node_modules and then in custom
  paths. ([#&#8203;5403](`https://github.com/facebook/jest/pull/5403`))
* `[jest-resolve]` Get builtin modules from node core.
  ([#&#8203;5411](`https://github.com/facebook/jest/pull/5411`))
* `[jest-resolve]` Detect and preserve absolute paths in `moduleDirectories`. Do
  not generate additional (invalid) paths by prepending each ancestor of `cwd`
  to the absolute path. Additionally, this fixes functionality in Windows OS.
  ([#&#8203;5398](`https://github.com/facebook/jest/pull/5398`))
##### Chore & Maintenance

* `[jest-util]` Implement watch plugins
  ([#&#8203;5399](`https://github.com/facebook/jest/pull/5399`))

---

### [`v22.2.2`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2222)

##### Fixes

* `[babel-jest]` Revert "Remove retainLines from babel-jest"
  ([#&#8203;5496](`https://github.com/facebook/jest/pull/5496`))
* `[jest-docblock]` Support multiple of the same `@pragma`.
  ([#&#8203;5154](`https://github.com/facebook/jest/pull/5502`))
##### Features

* `[jest-worker]` Assign a unique id for each worker and pass it to the child
  process. It will be available via `process.env.JEST_WORKER_ID`
  ([#&#8203;5494](`https://github.com/facebook/jest/pull/5494`))
##### Chore & Maintenance

* `[filenames]` Standardize file names in root
  ([#&#8203;5500](`https://github.com/facebook/jest/pull/5500`))

---

### [`v22.3.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2230)

##### Fixes

* `[expect]` Add descriptive error message to CalledWith methods when missing
  optional arguments ([#&#8203;5547](`https://github.com/facebook/jest/pull/5547`))
* `[jest-cli]` Fix inability to quit watch mode while debugger is still attached
  ([#&#8203;5029](`https://github.com/facebook/jest/pull/5029`))
* `[jest-haste-map]` Properly handle platform-specific file deletions
  ([#&#8203;5534](`https://github.com/facebook/jest/pull/5534`))
##### Features

* `[jest-util]` Add the following methods to the "console" implementations:
  `assert`, `count`, `countReset`, `dir`, `dirxml`, `group`, `groupCollapsed`,
  `groupEnd`, `time`, `timeEnd`
  ([#&#8203;5514](`https://github.com/facebook/jest/pull/5514`))
* `[docs]` Add documentation for interactive snapshot mode
  ([#&#8203;5291](`https://github.com/facebook/jest/pull/5291`))
* `[jest-editor-support]` Add watchAll flag
  ([#&#8203;5523](`https://github.com/facebook/jest/pull/5523`))
* `[jest-cli]` Support multiple glob patterns for `collectCoverageFrom`
  ([#&#8203;5537](`https://github.com/facebook/jest/pull/5537`))
* `[docs]` Add versioned documentation to the website
  ([#&#8203;5541](`https://github.com/facebook/jest/pull/5541`))
##### Chore & Maintenance

* `[jest-config]` Allow `<rootDir>` to be used with `collectCoverageFrom`
  ([#&#8203;5524](`https://github.com/facebook/jest/pull/5524`))
* `[filenames]` Standardize files names in "integration-tests" folder
  ([#&#8203;5513](`https://github.com/facebook/jest/pull/5513`))

---

### [`v22.4.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#&#8203;2240)

##### Fixes

* `[jest-haste-map]` Overhauls how Watchman crawler works fixing Windows
  ([#&#8203;5615](`https://github.com/facebook/jest/pull/5615`))
* `[expect]` Allow matching of Errors against plain objects
  ([#&#8203;5611](`https://github.com/facebook/jest/pull/5611`))
* `[jest-haste-map]` Do not read binary files in Haste, even when instructed to
  do so ([#&#8203;5612](`https://github.com/facebook/jest/pull/5612`))
* `[jest-cli]` Don't skip matchers for exact files
  ([#&#8203;5582](`https://github.com/facebook/jest/pull/5582`))
* `[docs]` Update discord links
  ([#&#8203;5586](`https://github.com/facebook/jest/pull/5586`))
* `[jest-runtime]` Align handling of testRegex on Windows between searching for
  tests and instrumentation checks
  ([#&#8203;5560](`https://github.com/facebook/jest/pull/5560`))
* `[jest-config]` Make it possible to merge `transform` option with preset
  ([#&#8203;5505](`https://github.com/facebook/jest/pull/5505`))
* `[jest-util]` Fix `console.assert` behavior in custom & buffered consoles
  ([#&#8203;5576](`https://github.com/facebook/jest/pull/5576`))
##### Features

* `[docs]` Add MongoDB guide
  ([#&#8203;5571](`https://github.com/facebook/jest/pull/5571`))
* `[jest-runtime]` Deprecate mapCoverage option.
  ([#&#8203;5177](`https://github.com/facebook/jest/pull/5177`))
* `[babel-jest]` Add option to return sourcemap from the transformer separately
  from source. ([#&#8203;5177](`https://github.com/facebook/jest/pull/5177`))
* `[jest-validate]` Add ability to log deprecation warnings for CLI flags.
  ([#&#8203;5536](`https://github.com/facebook/jest/pull/5536`))
* `[jest-serializer]` Added new module for serializing. Works using V8 or JSON
  ([#&#8203;5609](`https://github.com/facebook/jest/pull/5609`))
* `[docs]` Add a documentation note for project `displayName` configuration
  ([#&#8203;5600](`https://github.com/facebook/jest/pull/5600`))
##### Chore & Maintenance

* `[docs]` Update automatic mocks documentation
  ([#&#8203;5630](`https://github.com/facebook/jest/pull/5630`))

---

</details>