### PR TITLE
chore(deps): update dependency jsdom to ^11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -398,23 +398,6 @@
         }
       }
     },
-    "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
@@ -2453,6 +2436,12 @@
         "through2": "2.0.3",
         "umd": "3.0.3"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
     },
     "browser-resolve": {
       "version": "1.11.2",
@@ -8207,12 +8196,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-      "dev": true
-    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -8622,6 +8605,45 @@
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
       "dev": true
     },
+    "data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        }
+      }
+    },
     "date-fns": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
@@ -9000,6 +9022,15 @@
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
     },
     "domhandler": {
       "version": "2.4.1",
@@ -13613,36 +13644,90 @@
       }
     },
     "jsdom": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-      "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.7.0.tgz",
+      "integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
+        "acorn": "5.5.3",
+        "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
-        "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
+        "data-urls": "1.0.0",
+        "domexception": "1.0.1",
         "escodegen": "1.9.0",
         "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
-        "parse5": "1.5.1",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
         "request": "2.83.0",
+        "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
         "tough-cookie": "2.3.3",
+        "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.0",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+          "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.5.3"
+          }
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
           "dev": true
         }
       }
@@ -14346,6 +14431,12 @@
       "requires": {
         "invert-kv": "1.0.0"
       }
+    },
+    "left-pad": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -17997,12 +18088,6 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
-    "parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
-      "dev": true
-    },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
@@ -18279,6 +18364,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "podda": {
@@ -19851,6 +19942,26 @@
       "dev": true,
       "requires": {
         "throttleit": "1.0.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
       }
     },
     "requestretry": {
@@ -21570,6 +21681,12 @@
         "readable-stream": "2.3.4"
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
@@ -22358,12 +22475,6 @@
         "punycode": "1.4.1"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -22986,6 +23097,15 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
+      }
     },
     "warning": {
       "version": "3.0.0",
@@ -24185,23 +24305,11 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
-    "whatwg-url": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-      "dev": true,
-      "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        }
-      }
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
     },
     "when": {
       "version": "3.6.4",
@@ -24319,6 +24427,16 @@
         "slide": "1.1.6"
       }
     },
+    "ws": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
     "xdg-basedir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
@@ -24332,12 +24450,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
-      "dev": true
-    },
-    "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
       "dev": true
     },
     "xregexp": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "istanbul": "1.1.0-alpha.1",
     "istanbul-instrumenter-loader": "^3.0.0",
     "jasmine-core": "^3.0.0",
-    "jsdom": "^9.4.2",
+    "jsdom": "^11.0.0",
     "karma": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.0.2",


### PR DESCRIPTION
This Pull Request updates dependency [jsdom](https://github.com/jsdom/jsdom) from `^9.4.2` to `^11.0.0`



<details>
<summary>Release Notes</summary>

### [`v10.0.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1000)

This release includes a complete overhaul of jsdom's API for creating and manipulating jsdoms. The new API is meant to be much more intuitive and have better defaults, with complete documentation in the newly-overhauled README. We hope you like it!

As discussed in the new README, the old API is still available and supported via `require("jsdom/lib/old-api.js")`, at least until we have ported all of its features over to the new API. It will, however, not be gaining any new features, and we suggest you try the new API unless you really need the customizable resource loading the old API provides.

Apart from the new API, the following changes were made, with breaking changes bolded:

* **Removed support for Node.js v4 and v5**, as we have started using new JavaScript features only supported in Node.js v6 onwards.
* **Changed the `omitJsdomErrors` option to `omitJSDOMErrors`**, for consistency [with web platform APIs](https://w3ctag.github.io/design-principles/#casing-rules).
* Added `document.dir`. (Zirro)
* Updated the `<a>` and `<area>` APIs to the latest specification, and fixed a few bugs with them. (makana)
* Fixed `<img>` elements to no longer fire `"load"` events unless their image data is actually loaded (which generally only occurs when the `canvas` package is installed).
* Fixed `XMLHttpRequest` preflights to forward approved preflight headers to the actual request. (mbroadst)
* Fixed `htmlElement.dir` to properly restrict its values to `"ltr"`, `"rtl"`, or `"auto"`. (Zirro)
* Fixed setting `innerHTML` to the empty string to no longer be a no-op. (Zirro)
* Fixed the origin-checking logic in `window.postMessage()`, so that now you don't always have to pass an origin of `"*"`. (jmlopez-rod)
* Improved the `xhr.open()` error message when there are not enough arguments. (lencioni)

---

### [`v10.1.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1010)

* Added the value sanitization algorithm for password, search, tel, text, color, email, and url input types. (Zirro)
* Added `Symbol.toStringTag` to all web platform classes, so that now `Object.prototype.toString.call()` works as expected on jsdom objects.
* Added the `select.selectedOptions` property.
* Removed the `toString()` methods on various prototypes that returned `"[object ClassName]"` in an attempt to fake the `Symbol.toStringTag` behavior.
* Changed `XMLHttpRequest` to pre-allocate a 1 MiB buffer, which it grows exponentially as needed, in order to avoid frequent buffer allocation and concatenation. (skygon)
* Fixed a variety of properties that were meant to always return the same object, to actually do so. (Zirro)
* Fixed inheritance of the `runScripts` and `resources` options into iframes.
* Fixed an uncaught exception that occurred if you called `xhr.abort()` during a `"readystatechange"` event.

---

### [`v11.0.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1100)

Breaking changes:

* Custom parsers, via the `parser` option to the old API, can no longer be specified. They were never tested, often broken, and a maintenance burden. The defaults, of [parse5](https://www.npmjs.com/package/parse5) for HTML and [sax](https://www.npmjs.com/package/sax) for XML, now always apply.
* Due to a parse5 upgrade, the location info objects returned by `dom.nodeLocation()` or the old API's `jsdom.nodeLocation()` now have a different structure.
* Fixed how `runScripts` applies to event handler attributes; now they will no longer be converted into event handler functions unless `runScripts: "dangerously"` is set. However, event handler _properties_ will now work with any `runScripts` option value, instead of being blocked.

Other changes:

* Overhauled how event handler properties and attributes work to follow the spec. In particular, this adds various `oneventname` properties to various prototypes, ensures the correct order when interleaving event handlers and other event listeners, and ensures that event handlers are evaluated with the correct values in scope.
* Upgraded parse5 from v1 to v3, bringing along several correctness improvements to HTML parsing. (Zirro)
* Updated `Location` properties to be on the instance, instead of the prototype, and to be non-configurable.
* Significantly improved the performance of `HTMLCollection`, and thus of parsing large documents. (Zirro)
* Significantly improved the performance of `getComputedStyle()` by removing unsupported selectors from the default style sheet. (flaviut)
* Fixed all web platform methods that accepted web platform objects to perform proper type checks on them, throwing a `TypeError` when given invalid values. (TimothyGu)
* Fixed the `Symbol.toStringTag` properties to be non-writable and non-enumerable. (TimothyGu)
* Fixed `tokenList.remove()` when the `DOMTokenList` corresponded to a non-existant attribute. (Zirro)
* Fixed `fileReader.abort()` to terminate ongoing reads properly.
* Fixed `xhr.send()` to support array buffer views, not just `ArrayBuffer`s. (ondras)
* Fixed non-`GET` requests to `data:` URLs using `XMLHttpRequest`. (Zirro)
* Fixed form submission to no longer happen for disconnected forms.
* Fixed body event handler attributes to be treated like all others in terms of how they interact with `runScripts`.
* Many updates per recent spec changes: (Zirro)
  * Updated `tokenList.replace()` edge-case behavior.
  * Invalid qualified names now throw `"InvalidCharacterError"` `DOMException`s, instead of `"NamespaceError"` `DOMException`s.
  * Changed `input.select()` to no longer throw on types where selection does not apply.
  * Updated `event.initEvent()` and various related methods to have additional defaults.
  * Stopped lowercasing headers in `XMLHttpRequest` responses.
  * Started lowercasing headers in `xhr.getAllResponseHeaders()`, and separating the header values with a comma-space (not just a comma).
  * Allow a redirect after a CORS preflight when using `XMLHttpRequest`.
  * Tweaked username/password CORS treatment when using `XMLHttpRequest`.
  * Changed `xhr.overrideMimeType()` to no longer throw for invalid input.
  * Removed `blob.close()` and `blob.isClosed()`.
* Removed some remaining not-per-spec `toString()` methods on various prototypes, which were made redundant in v10.1.0 but we forgot to remove.

---

### [`v11.1.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1110)

* Added `javascript:` URL "navigation" via `window.location`, at least by evaluating the side effects. It still doesn't actually navigate anywhere. (ForbesLindesay)
* Updated `whatwg-url` to v6.1.0, bringing along origin serialization changes and `URLSearchParams` among various other fixes. (ForbesLindesay)
* Fixed `javascript:` URL loading for iframes to do proper percent-decoding and error reporting.
* Fixed corrupted `XMLHttpRequest` responses when they were over 1 MiB.
* Fixed timers to not start after a window is `close()`d, which could cause strange errors since most objects are unusable at that point. (Enverbalalic)

---

### [`v11.2.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1120)

This release brings with it a much-awaited infrastructure change, as part of [webidl2js v7.3.0](https://github.com/jsdom/webidl2js/releases/tag/v7.3.0) by the ever-amazing TimothyGu: jsdom can now generate spec-compliant versions of classes that have "`Proxy`-like" behavior, i.e. allow getting or setting keys in unusual ways. This enables a number of improvements, also by TimothyGu:

* Significantly improved the spec-compliance and "liveness" of both `NodeList` and `HTMLCollection`, such that retrieving properties via indices or (in `HTMLCollection`'s case) `id`/`name` values will always work correctly.
* Added `element.dataset` support.
* Added indexed and named access to `<select>` elements, as well as the corresponding `item()` and `namedItem()` methods.
* Added suport for `FileList` indexed properties, i.e. `fileList[i]`.
* Made `select.options` an instance of the newly-implemented `HTMLOptionsCollection`, instead of just a `HTMLCollection`.

This infrastructure will allow us to improve and implement many other similar behaviors; that work is being tracked in [#&#8203;1129](`https://github.com/tmpvar/jsdom/issues/1129`).

In addition to these improvements to the object model, we have more work to share:

* Added no-op APIs `document.clear()`, `document.captureEvents()`, `document.releaseEvents()`, `window.external.AddSearchProvider()`, and `window.external.IsSearchProviderInstalled()`. (Zirro)
* Added active checks to prevent reentrancy in `TreeWalker` and `NodeIterator`.
* Updated the interaction between a `<textarea>`'s `value`, `defaultValue`, and `textContent` per [a recent spec change](https://github.com/whatwg/html/commit/5afbba1cf62ee01bc6af3fd220d01f3f7591a0fc)
* Fixed elements with `id="undefined"` shadowing the `undefined` property of the global object. (TimothyGu)
* Fixed matching in `getElementsByClassName()` to be ASCII case-insensitive, instead of using JavaScript's `toLowerCase()`.
* Improved some behaviors around navigating to fragments. (ForbesLindesay)
* Improved `XMLHttpRequest` and `FileReader` behavior, mainly around event handlers, `abort()`, and network errors.
* Improved edge-case spec compliance of `NodeIterator`.

---

### [`v11.3.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1130)

For this release we'd like to formally welcome [@&#8203;TimothyGu](https://github.com/tmpvar/jsdom/commits?author=TimothyGu) to the core team, as a prolific contributor. He will join the illustrious ranks of those who do so much work on jsdom that we no longer note their names in the changelog.

* Added `table.tHead`, `table.tFoot`, and `table.caption` setters, and the `table.createTBody()` method.
* Added `CompositionEvent` and `WheelEvent` classes.
* Added a `<details>` element implementation. (Zirro)
* Added stub `<marquee>` and `<picture>` element implementations. (Zirro)
* Updated `uiEvent.initUIEvent()`, `keyboardEvent.initKeyboardEvent()`, and `mouseEvent.initiMouseEvent()` to match the latest specifications.
* Converted `DOMTokenList` (used by, e.g., `element.classList`) to use proxies for improved specification compliance and "liveness".
* Fixed the `DOMException` class to be spec-compliant, including its constructor signature.
* Fixed some subtle interactions between inline event handlers and other event listeners.
* Fixed the element interface used when creating many of the more obscure elements.
* Fixed the behavior of the `table.rows` getter, and the `table.createCaption()` and `table.deleteRow()` methods.
* Fixed incorrect sharing of methods between interfaces that used mixins (e.g. previously `document.querySelector === documentFragment.querySelector`, incorrectly).
* Fixed `FocusEvent` creation, which regressed in v11.2.0.
* Fixed `UIEvent` to only allow initializing with `Window` objects for its `view` property.
* Fixed the behavior of `tr.rowIndex` and `tr.deleteCall()`.
* Fixed the element interface for `<td>` and `<th>` to be simply `HTMLTableCellElement`, and improved that class's spec compliance.
* Fixed calling `label.click()` to not trigger the labeled control's activation behavior when the control is disabled. (schreifels)
* Fixed `document.getElementsByName()` to return a `NodeList` instead of a `HTMLCollection`. (Zirro)
* Significantly sped up synchronous `XMLHttpRequest`. (Zirro)

---

### [`v11.4.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1140)

For this release we'd like to welcome [@&#8203;Zirro](https://github.com/tmpvar/jsdom/commits?author=Zirro) to the core team; his contributions over the course of this year have enhanced jsdom immensely.

* Added a rudimentary set of SVG element classes, namely `SVGElement`, `SVGGraphicsElement`, `SVGSVGElement`, `SVGTests`, `SVGAnimatedString`, `SVGNumber`, and `SVGStringList`. The main impact here is that SVG elements are now instances of `SVGElement`, instead of being simply `Element` (as they were in v11.3.0) or `HTMLUnknownElement` (as they were in v11.2.0 and previously). The only concrete subclass that is implemented is `SVGSVGElement`, for `<svg>` itself; other tags will not map to their correct classes, because those classes are not yet implemented.
* Added the new `pretendToBeVisual` option, which controls the presence of the new `requestAnimationFrame()` and `cancelAnimationFrame()` methods, and the new values of `document.hidden`/`document.visibilityState`. [See the README](https://github.com/tmpvar/jsdom#pretending-to-be-a-visual-browser) for more information. (SimenB)
* Added the `append()` and `prepend()` methods to `Document`, `DocumentFragment`, and `Element`. (caub)
* Added the `before()`, `after()`, and `replaceWith()` methods to `DocumentType`, `Element`, and `CharacterData`. (caub)
* Added `node.isConnected`.
* Added `node.isSameNode()`.
* Added support for parsing CDATA sections in XML documents, including in `domParser.parseFromString()`. (myabc)
* Added appropriate `input.value` getter/setter logic for `<input type="file">`.
* Significantly improved the spec-compliance of `NamedNodeMap`, i.e. of `element.attributes`, such that retrieving named or indexed properties will now always work properly.
* Fixed `domParser.parseFromString()` to not parse HTML character entities in XML documents. (myabc)
* Fixed `xhr.abort()` to clear any set headers.
* Fixed `XMLHttpRequest` to always decoded responses as UTF-8 when `responseType` is set to `"json"`.
* Fixed `XMLHttpRequest` CORS header handling, especially with regard to preflights and Access-Control-Allow-Headers. (ScottAlbertine)
* Fixed the behavior of `radioButton.click()` to fire appropriate `input` and `change` events. (liqwid)
* Fixed `querySelector()`/`querySelectorAll()` behavior for SVG elements inside `<template>` contents `DocumentFragment`s, including those created by `JSDOM.fragment()`. (caub)
* Fixed the line number reporting in exception stack traces when using `<script>` elements, when `includeNodeLocations` is set.
* Removed the `<applet>` element, [following the spec](`https://github.com/whatwg/html/pull/1399`).

---

### [`v11.5.1`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1151)

(This should have been a minor release; oops.)

* Added `AbortSignal` and `AbortController`.
* Fixed validation for file `<input>`s and implemented validation for more input types.

---

### [`v11.6.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1160)

* Added a fully-functioning `WebSocket` implementation!
* Added a `window.performance` implementation, including the basics of the [High Resolution Time](https://w3c.github.io/hr-time/) specification: `performance.now()`, `performance.timeOrigin`, and `performance.toJSON()`.
* Added support for all of the public API of `HTMLMeterElement`, except for `meterEl.labels`.
* Added the `locationbar`, `menubar`, `personalbar`, `scrollbars`, `statusbar`, and `toolbar` properties to `Window`.
* Added more properties to `window.screen`: `availWidth`, `availHeight`, `colorDepth`, and `pixelDepth`. All of its properties are now getters as well.
* Added `window.devicePixelRatio`.
* Added `getModifierState()` to `MouseEvent` and `KeyboardEvent`.
* Added a setter for `HTMLInputElement`'s `files` property.
* Added support for the `endings` option to the `Blob` constructor.
* Fixed firing various event firings to have the correct default values, e.g. the properties of `MouseEvent` when using `element.click()`.
* Fixed the firing of `popstate` and `hashchange` events during fragment navigation to make them trusted events.
* Fixed `data:` URL parsing to not include the fragment portions.
* Fixed all URL-accepting properties to properly perform [scalar value string conversion](https://infra.spec.whatwg.org/#javascript-string-convert) and URL resolution.
* Fixed many other small edge-case conformance issues in the API surface of various web APIs; see [#&#8203;2053](`https://github.com/tmpvar/jsdom/pull/2053`) and [#&#8203;2081](`https://github.com/tmpvar/jsdom/pull/2081`) for more information.
* Fixed various APIs to use ASCII lowercasing, instead of Unicode lowercasing, for element and attribute names.
* Fixed the encoding of a document created via `new Document()` to be UTF-8.
* Fixed event handler properties behavior when given non-callable objects.
* Increased the performance of parsing HTML documents with large numbers of sibling elements.
* Removed `probablySupportsContext()` and `setContext()` from `HTMLCanvasElement`, per spec updates.
* Removed the nonstandard `window.scrollLeft` and `window.scrollTop` properties, and the `window.createPopup()` method.

---

### [`v11.6.1`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1161)

* Fixed one regression (since v11.6.0) in `<style>` elements, where their `sheet` property would sometimes be `null` when it should not be.
* Fixed a case where a `<style>` element's `sheet` property would be left as a `CSSStyleSheet` despite it not being in the document.

Another regression remains where we are emitting spurious CSS-parsing `"jsdomError"` events; see [#&#8203;2123](`https://github.com/tmpvar/jsdom/issues/2123`). We also discovered a large amount of preexisting brokenness around `<style>`, `<link>`, and `@import`; see [#&#8203;2124](`https://github.com/tmpvar/jsdom/issues/2124`) for more details.

We'll try to fix these soon, especially the regression.

---

### [`v11.6.2`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1162)

* Fixed another regression (since v11.6.0) in `<style>` elements, where they would omit a series of parsing `"jsdomError"`s for any style sheet text containing spaces.
* Generally improved the spec-conformance of when `<style>` and `<script>` elements are evaluated; for example, `<script>` elements inserted by `innerHTML` are no longer evaluated.

---

### [`v11.7.0`](https://github.com/jsdom/jsdom/blob/master/CHANGELOG.md#&#8203;1170)

* Added the boolean return value to `DOMTokenList`'s `replace()` method, per the recent spec addition.
* Added `FileReader`'s `readAsBinaryString()` method, as it has been added back to the specification.
* Fixed event handlers to be own properties of each `Window`, instead of on `Window.prototype`. (Fetz)
* Fixed an exception that would sometimes get raised when removing an `<img>` element's `src=""` attribute. (atsikov)
* Fixed `"abort"` events on `AbortSignal`s to have their `isTrusted` set to true.
* Fixed some argument conversions in `XMLHttpRequest`'s `open()` method.
* Improved MIME type and data: URL parsing throughout jsdom, by using the new [`whatwg-mimetype`](https://www.npmjs.com/package/whatwg-mimetype) and [`data-urls`](https://www.npmjs.com/package/data-urls) packages.

---

</details>


<details>
<summary>Commits</summary>

#### v11.4.0
-   [`2456d60`](https://github.com/jsdom/jsdom/commit/2456d6053bf472347892ab0dbf68047b91c4e0c0) Yarn followup
-   [`a3594bc`](https://github.com/jsdom/jsdom/commit/a3594bcc3746604c37b55347616fd15a2169bd05) Correct DOMParser parsing of HTML entities in XML
-   [`8a6894c`](https://github.com/jsdom/jsdom/commit/8a6894c34f14b9131d0fe4acadb71dae4f49daca) Add {request,cancel}AnimationFrame and pretendToBeVisual
-   [`089afa8`](https://github.com/jsdom/jsdom/commit/089afa8773a1409c0e74ad24cc64a279faf8debf) Teach jsdom to parse XML CDATA sections
-   [`87e9593`](https://github.com/jsdom/jsdom/commit/87e95931cb8ad1b509a96daa9f6f59987ed5c3cf) Skip stack trace line number test in browsers
-   [`7a73cf6`](https://github.com/jsdom/jsdom/commit/7a73cf6bee906c3553fb8b7fd7238dc37528535f) Update contributor name to .mailmap; update AUTHORS.txt
-   [`ef2a5ec`](https://github.com/jsdom/jsdom/commit/ef2a5ec94c90e419a69ecdbba97c41f9debbb4eb) Fix needs-* checks in tests
-   [`54ea97b`](https://github.com/jsdom/jsdom/commit/54ea97bdf489b101c75e62d2ecc8a60c49e202b5) Allow mixing in symbols
-   [`c33816b`](https://github.com/jsdom/jsdom/commit/c33816baeeb801448fe0b82286fb4f71278862a2) Refactor HTMLElement
-   [`e2ea031`](https://github.com/jsdom/jsdom/commit/e2ea031fd763cd65dcd152f915f844a9ad74fb5d) A better SVG implementation
-   [`1e5434c`](https://github.com/jsdom/jsdom/commit/1e5434c3f42765df7bf13a25632fb23de9323dcd) Test that we are not mutating the passed-in options object
-   [`e5c2e32`](https://github.com/jsdom/jsdom/commit/e5c2e324f42d37bdd24c10a2f41662036d1375ef) Fix typo in README
-   [`6164c93`](https://github.com/jsdom/jsdom/commit/6164c93266c9a70fb5003c5d7a2608a9766e9ed2) Fix broken link to Attr.webidl in Contributing.md
-   [`d4612e7`](https://github.com/jsdom/jsdom/commit/d4612e7dff4355c633f5687d95f3c8f64575fcd1) Roll web-platform-tests
-   [`d13922a`](https://github.com/jsdom/jsdom/commit/d13922a2a5b09612d019c807fe3532d351c394f1) Clear headers on XHR abort()
-   [`e7b68fa`](https://github.com/jsdom/jsdom/commit/e7b68fa33db497aa1ddb5dbfc14f2bc53242e3a8) Add &lt;input&gt; value handling for the filename mode
-   [`587151f`](https://github.com/jsdom/jsdom/commit/587151f2f1536b9626ff4bbfd431ab39552640bf) Always decode responseType &quot;json&quot; as UTF-8
-   [`2b70aef`](https://github.com/jsdom/jsdom/commit/2b70aefc1b7ccbf2ac81e46f94febd55662093d8) Implement Node.isConnected and Node.isSameNode()
-   [`d12bea1`](https://github.com/jsdom/jsdom/commit/d12bea1fe419fec4895650122c3f5175e6496a4f) List execution-timing tests as failing in Node 6
-   [`b5b5dba`](https://github.com/jsdom/jsdom/commit/b5b5dba29e06cf42e1a517d8fb12a171912b877a) Disable tests we are not going to be able to pass this roll
-   [`d6cba38`](https://github.com/jsdom/jsdom/commit/d6cba380fcb61ee39e26099900825982e22d8b64) Convert NamedNodeMap to use IDL
-   [`f0ecb6d`](https://github.com/jsdom/jsdom/commit/f0ecb6d17a53adfe8d0fabd4915271e36ae420a1) Fix some XMLHttpRequest CORS header issues
-   [`fefbd7a`](https://github.com/jsdom/jsdom/commit/fefbd7ae8947d16c9085f262b281f6c274ba6b6e) Give radio buttons activation behavior too, not just checkboxes
-   [`35775cc`](https://github.com/jsdom/jsdom/commit/35775ccb77b40e7c42997b6c9adf69e34fd78c08) Don&#x27;t do radio button activation behavior if it&#x27;s already checked
-   [`f08fd3b`](https://github.com/jsdom/jsdom/commit/f08fd3bc81d9b10bc37f2d007cf2dfcd92aa0a6a) Fix querySelector for SVG elements inside template fragments
-   [`1b91696`](https://github.com/jsdom/jsdom/commit/1b9169659246ab394b4418061c1db1c3c65ecc81) Add append(), prepend(), after(), before(), and replaceWith()
-   [`f61299c`](https://github.com/jsdom/jsdom/commit/f61299c592bfdfeaac688bcf248a84dfe1587f8b) Remove the &lt;applet&gt; element
-   [`cef555a`](https://github.com/jsdom/jsdom/commit/cef555ae75bbfdf8bebea3af8ca7908ecb9ee3ff) Version 11.4.0
#### v11.5.0
-   [`ea6a0be`](https://github.com/jsdom/jsdom/commit/ea6a0be06ff9966c5af49a8ea830c6807bbdd7af) Small fixes to the changelog
-   [`87b7f11`](https://github.com/jsdom/jsdom/commit/87b7f11dc0aa9ed03331da300ab9831cd609ca0c) Add a reset-wpt script
-   [`1b72d6c`](https://github.com/jsdom/jsdom/commit/1b72d6c450c11483a226a9fc0d1558d78637a30b) Implement AbortController and AbortSignal
-   [`f8a6d12`](https://github.com/jsdom/jsdom/commit/f8a6d1215ca74036a4c93409857ef2372feb167e) Enhance &lt;input&gt;.value support for exotic types
-   [`26edf1c`](https://github.com/jsdom/jsdom/commit/26edf1c53e2ad7049b645328df56ef67f716c7c1) Implement &lt;input type&#x3D;checkbox&gt;.indeterminate
-   [`b921820`](https://github.com/jsdom/jsdom/commit/b921820a89ba13bca0b4dadf18776b5a97cacd7b) More comprehensive messages about &lt;input&gt; test failures
#### v11.5.1
-   [`4e7dcca`](https://github.com/jsdom/jsdom/commit/4e7dccaf336798573b03179992134b650ffa97ab) Version 11.5.1
#### v11.6.0
-   [`ad921b2`](https://github.com/jsdom/jsdom/commit/ad921b255f96d4ae87d66209f9a0f1e353486a21) Start web platform tests server before tests run
-   [`b8f4cc1`](https://github.com/jsdom/jsdom/commit/b8f4cc16a69296259e973d0bfdb3f94b98d2132c) Don&#x27;t include fragment in data: URL body
-   [`224d286`](https://github.com/jsdom/jsdom/commit/224d28614bb8bb5f012c61545edd3767583d3d10) Update dependencies
-   [`704f545`](https://github.com/jsdom/jsdom/commit/704f545e008b355d3feee0da59b8fac4115038e9) Update to new webidl2js
-   [`8d060a8`](https://github.com/jsdom/jsdom/commit/8d060a88b6073d2be825e43d30933d5a2e44ac0c) Update all Web IDL in nodes/
-   [`ff6ee3f`](https://github.com/jsdom/jsdom/commit/ff6ee3fd165dbabac8d3965f8822790fff8d96d8) Remove obsolete &lt;canvas&gt; methods
-   [`98950bc`](https://github.com/jsdom/jsdom/commit/98950bcded2b0e82272d2b6ad2b74141421e2f9e) Add a setter for inputEl.files
-   [`0052c6c`](https://github.com/jsdom/jsdom/commit/0052c6c2e41556c96b283f28825311b07a0e0db9) Update EventHandlers according to their IDL
-   [`d4d1cfe`](https://github.com/jsdom/jsdom/commit/d4d1cfea86d894ed665911dca0b39b626df56c0b) Handle USVString reflection
-   [`4c7698f`](https://github.com/jsdom/jsdom/commit/4c7698f760fc64f20b2a0ddff450eddbdd193176) Remove old longDesc test which no longer seems correct
-   [`aeca582`](https://github.com/jsdom/jsdom/commit/aeca58248f16b8e3eca81fd0690735ea586a2afb) Enable &#x27;option-text-setter&#x27; test which passes
-   [`05a6deb`](https://github.com/jsdom/jsdom/commit/05a6deb6b91b4e02c53ce240116146e59f7e14d7) Update yarn.lock
-   [`0c8f4eb`](https://github.com/jsdom/jsdom/commit/0c8f4eb701395c0d0ace9a37b7c48e0a2c7c5f90) Give failing tests on Travis a second chance
-   [`b65716c`](https://github.com/jsdom/jsdom/commit/b65716c3af5a2ccdadd73de41f41d075cea01bb8) Implement BarProp (Browser interface elements)
-   [`31bdee1`](https://github.com/jsdom/jsdom/commit/31bdee1cfd5ef8505b59dd625d5867ced2de260c) Implement the Screen interface
-   [`9622508`](https://github.com/jsdom/jsdom/commit/9622508ecf062ab853a7c460d2da4dbc79b46224) Implement window.devicePixelRatio
-   [`0463f71`](https://github.com/jsdom/jsdom/commit/0463f713927f0ccbe3312342cbc8616278b5ff8f) Enable certain tests for CSSOM View
-   [`30dc938`](https://github.com/jsdom/jsdom/commit/30dc938d3ab2e96a1853ee64ab97dcdf106a7288) Add note regarding the window.status attribute
-   [`bf9fab1`](https://github.com/jsdom/jsdom/commit/bf9fab17742b2971a9be45bcc97cd0002b672e6e) Use ASCII lowercase for localName and getElementsByTagName()
-   [`5bc6b3b`](https://github.com/jsdom/jsdom/commit/5bc6b3bbcc0f18eccecca551bfcfe7d6bbe3e2ba) Set Document&#x27;s default encoding to UTF-8
-   [`b9f127b`](https://github.com/jsdom/jsdom/commit/b9f127b0501a5e839ba1879eb1543c2616f616d8) Remove non-standard window.scrollLeft/scrollTop properties
-   [`39043e9`](https://github.com/jsdom/jsdom/commit/39043e947fac289d62a527f4cc08f83578685e8b) Add note regarding window.screenLeft/screenTop
-   [`f7f0b80`](https://github.com/jsdom/jsdom/commit/f7f0b80a84ce7c4b01b8e206de3fce8091df0bd4) Remove non-standard window.createPopup() stub
-   [`9b5d91f`](https://github.com/jsdom/jsdom/commit/9b5d91f8135cf9eb25ea90cd6b92c236355cf8df) Implement BlobPropertyBag#endings
-   [`2cf02a8`](https://github.com/jsdom/jsdom/commit/2cf02a84d2c4d30afb8691083aad28efae03bb66) Make HashChangeEvent and PopStateEvent trusted
-   [`e7fc3a9`](https://github.com/jsdom/jsdom/commit/e7fc3a938f7e5ec783f365f0d31165cf772c92c9) Roll whatwg-url
-   [`7e5e7dc`](https://github.com/jsdom/jsdom/commit/7e5e7dcdf639313119ce8a642e2d84617468929e) Allow non-callable objects for event IDL attributes
-   [`cb8ea4c`](https://github.com/jsdom/jsdom/commit/cb8ea4ca5667d799aa7be84565e24e1785bda54e) Roll WPT
-   [`fffa146`](https://github.com/jsdom/jsdom/commit/fffa146aea937d3a3a9386db524bc76b46e27d42) Protect against global mutation in Event classes
-   [`71d869d`](https://github.com/jsdom/jsdom/commit/71d869dccc6751e11f04847ad2156b1a1dcfecaa) Copy default params in Event constructor
-   [`4fa53f6`](https://github.com/jsdom/jsdom/commit/4fa53f626f7cdcc3e5f4308f06dc9cff57d7694f) Implement Keyboard/MouseEvent#getModifierState
-   [`9bb9297`](https://github.com/jsdom/jsdom/commit/9bb929712f951035304800980d08af58fb697f92) Set view attribute in HTMLElement#click
-   [`2b5447a`](https://github.com/jsdom/jsdom/commit/2b5447a5126116664a59557e2a56d4a14b0a6d24) Enable currently passing uievents WPTs
-   [`144b39b`](https://github.com/jsdom/jsdom/commit/144b39b726eabde92abdfaa362cd68f1d544d138) Implement WebSocket
-   [`1519104`](https://github.com/jsdom/jsdom/commit/1519104a1d0eea69e13b4c18c222a559d20829cb) Update Web IDL outside nodes/
-   [`e2ddfb7`](https://github.com/jsdom/jsdom/commit/e2ddfb7a9048df2155dc651f571c53145fdd3189) Implement more parts of &lt;meter&gt;
-   [`8c84ebf`](https://github.com/jsdom/jsdom/commit/8c84ebf3b7f3420b6e6cc68612ed3e0b9c1f4455) Overhaul HTML parsing infrastructure
-   [`ecdf27c`](https://github.com/jsdom/jsdom/commit/ecdf27cc3a17970aee508bf95e9268d3d9625a26) Upgrade parse5 to v4.0.0
-   [`b9dac94`](https://github.com/jsdom/jsdom/commit/b9dac947fcc54498200677308bfc36b296388a10) Upgrade in-range dependencies
-   [`12a5e12`](https://github.com/jsdom/jsdom/commit/12a5e12e3942bdb821c156ef0159bdb9f39cf4b2) Implement window.performance
-   [`cb523d1`](https://github.com/jsdom/jsdom/commit/cb523d1c7a4349ba75e79ca9825d92882ccb13fa) Add documentation about &quot;yarn pretest&quot;
-   [`9f1c9aa`](https://github.com/jsdom/jsdom/commit/9f1c9aa4063ac91aba2a1f8d382b0f89e2fa46c1) Make WebSocket compatible with browsers
-   [`ad0e551`](https://github.com/jsdom/jsdom/commit/ad0e551b1b633e07d11f98d7a30287491958def3) Fix hr-time tests after WPT roll
-   [`dc150a1`](https://github.com/jsdom/jsdom/commit/dc150a182db8cb17a682e21073c43efd9e0ad2a0) Version 11.6.0
#### v11.6.1
-   [`0c54ed3`](https://github.com/jsdom/jsdom/commit/0c54ed399b7399d3ab86e8a9d59fa7ea34e060da) Fix &lt;style&gt;&#x27;s sheet property
-   [`450b915`](https://github.com/jsdom/jsdom/commit/450b915cc68b6581b9b26a312837fa993ef8b4cd) Version 11.6.1
#### v11.6.2
-   [`dbda070`](https://github.com/jsdom/jsdom/commit/dbda070c9d33fb2762abedc23376757d9f8ec7d3) Fix &lt;style&gt; and &lt;script&gt; parsing to wait for their close tag
-   [`f32113b`](https://github.com/jsdom/jsdom/commit/f32113b6e1307832eb75d295d9da8185dd27006a) Further fix &lt;style&gt; and &lt;script&gt; evaluation semantics
-   [`71dc01b`](https://github.com/jsdom/jsdom/commit/71dc01b6f3c425bd395751648bf46bf55a13b79d) Update maintainer and repository information
-   [`1cd4831`](https://github.com/jsdom/jsdom/commit/1cd4831e36b40c8041237d5cf184f229f358ffc0) Version 11.6.2
#### v11.7.0
-   [`475a7cd`](https://github.com/jsdom/jsdom/commit/475a7cde88df30a2d38bff583ebcc5bc5a6880f6) Omit *.webidl from the published package
-   [`a0b7f8a`](https://github.com/jsdom/jsdom/commit/a0b7f8a77789fbc4467031a19865a2d1aef27796) Remove no-longer-used field from HTMLStyleElementImpl
-   [`830a6fd`](https://github.com/jsdom/jsdom/commit/830a6fdab5af9041f901a2316e7c74e8d88d91a2) Fix event handlers to be own properties of each Window
-   [`d563965`](https://github.com/jsdom/jsdom/commit/d5639655d32d45b6690c9ac30901136e650eb99a) Use whatwg-mimetype and data-urls packages
-   [`dc672a2`](https://github.com/jsdom/jsdom/commit/dc672a2544bd269cfbf311ae7ab0d06aa4d8d170) Fix removing an &lt;img&gt;&#x27;s src&#x3D;&quot;&quot; attribute
-   [`c520198`](https://github.com/jsdom/jsdom/commit/c52019862dc8f427a7f91455a64e50cc36a3ca6c) Implement requestAnimationFrame using performance.now
-   [`70ec93b`](https://github.com/jsdom/jsdom/commit/70ec93b436daf6d5b1d79a738226106819d25dc1) Add README entry about jsdom-devtools-formatter
-   [`a38c181`](https://github.com/jsdom/jsdom/commit/a38c181be8011c0ff9e05657a6485fd54a104fd0) Cross-reference external script loading from script execution docs
-   [`c91440a`](https://github.com/jsdom/jsdom/commit/c91440a97bc826ae79627655f860c66a63583007) Update web platform tests
-   [`d80648f`](https://github.com/jsdom/jsdom/commit/d80648f8854a168d33eec16bbac453ebbf0b4820) Set abort event isTrusted to true
-   [`5e86716`](https://github.com/jsdom/jsdom/commit/5e8671643bb0f0cc8e23c382c431ac8424736e88) Implement FileReader.readAsBinaryString()
-   [`8ad6b17`](https://github.com/jsdom/jsdom/commit/8ad6b17de8e48db5d7a1a6cbd2660968bb5c16f3) Convert several of XHR open()&#x27;s arguments to strings
-   [`7f41ae5`](https://github.com/jsdom/jsdom/commit/7f41ae54417492d9a111ce4c24e08cc2cc917a4c) Return boolean from DOMTokenList.replace()
-   [`8767d9f`](https://github.com/jsdom/jsdom/commit/8767d9f923b382f250b9b571fdb6d8f4d54adad1) Note that FileAPI/historical.https.html needs async/await
-   [`1e5bbd2`](https://github.com/jsdom/jsdom/commit/1e5bbd2638902a878c563e6e0e7a475d1bd37517) Version 11.7.0

</details>