### PR TITLE
chore(deps): update dependency webpack to ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2692,15 +2692,6 @@
         "parse-asn1": "5.1.0"
       }
     },
-    "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true,
-      "requires": {
-        "pako": "0.2.9"
-      }
-    },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
@@ -2780,6 +2771,35 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "cacache": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.1",
+        "mississippi": "2.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.2",
+        "ssri": "5.3.0",
+        "unique-filename": "1.1.0",
+        "y18n": "4.0.0"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        }
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -3064,6 +3084,18 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
+    "chrome-trace-event": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz",
+      "integrity": "sha1-kPNohdU0WlBiEzLwcXtZWIPV2YI=",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -8228,6 +8260,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -8591,6 +8637,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
     "d": {
@@ -9068,6 +9120,18 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "duplexify": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4",
+        "stream-shift": "1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -9172,25 +9236,6 @@
       "dev": true,
       "requires": {
         "once": "1.4.0"
-      }
-    },
-    "enhanced-resolve": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-      "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.2.0",
-        "tapable": "0.1.10"
-      },
-      "dependencies": {
-        "memory-fs": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
-          "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
-          "dev": true
-        }
       }
     },
     "ent": {
@@ -10496,6 +10541,16 @@
       "integrity": "sha1-N4tRKNbQtVSosvFqTKPhq5ZJ8A4=",
       "dev": true
     },
+    "flush-write-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4"
+      }
+    },
     "follow-redirects": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
@@ -10586,6 +10641,18 @@
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.4"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -12443,12 +12510,6 @@
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
       "dev": true
     },
-    "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
-      "dev": true
-    },
     "https-proxy-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
@@ -12550,6 +12611,12 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.7",
@@ -15545,16 +15612,6 @@
         }
       }
     },
-    "memory-fs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-      "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.4"
-      }
-    },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -15671,6 +15728,24 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mississippi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+      "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "duplexify": "3.5.4",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.0.3",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "2.0.1",
+        "pumpify": "1.4.0",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
+      }
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -15916,6 +15991,20 @@
       "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
       "integrity": "sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4=",
       "dev": true
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -16971,45 +17060,6 @@
         }
       }
     },
-    "node-libs-browser": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
-      "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
-      "dev": true,
-      "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.3.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.4",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
-        "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.6",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
-      },
-      "dependencies": {
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "node-sass": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
@@ -17757,12 +17807,6 @@
         }
       }
     },
-    "os-browserify": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
-      "dev": true
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -17921,11 +17965,16 @@
         }
       }
     },
-    "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
-      "dev": true
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4"
+      }
     },
     "param-case": {
       "version": "2.1.1",
@@ -19094,6 +19143,12 @@
         "asap": "2.0.6"
       }
     },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
     "promise.prototype.finally": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
@@ -19187,6 +19242,27 @@
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
         "randombytes": "2.0.6"
+      }
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
+    "pumpify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+      "dev": true,
+      "requires": {
+        "duplexify": "3.5.4",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -20022,6 +20098,15 @@
       "integrity": "sha512-e5t1NVhr5VWmD9V9U4KjjSGkf5w6CcTPgw11A3CfIvkkQxlAKzX3usPUp1NUQTmpOOjU+f9QRICU3tMbKwn9ZQ==",
       "dev": true
     },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0"
+      }
+    },
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
@@ -20438,6 +20523,12 @@
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
       }
+    },
+    "serialize-javascript": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
+      "dev": true
     },
     "serve-favicon": {
       "version": "2.4.5",
@@ -21017,6 +21108,15 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "ssri": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+      "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -21589,6 +21689,16 @@
         "readable-stream": "2.3.4"
       }
     },
+    "stream-each": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
+      }
+    },
     "stream-http": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
@@ -21600,6 +21710,12 @@
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
     },
     "stream-splicer": {
       "version": "2.0.0",
@@ -22144,12 +22260,6 @@
         }
       }
     },
-    "tapable": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
-      "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
-      "dev": true
-    },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -22462,6 +22572,30 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
+    "uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "uglify-js": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
@@ -22611,6 +22745,24 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
+    },
+    "unique-filename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "0.1.4"
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -22996,25 +23148,6 @@
         "loose-envify": "1.3.1"
       }
     },
-    "watchpack": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
-      "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
-      "dev": true,
-      "requires": {
-        "async": "0.9.2",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        }
-      }
-    },
     "wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -23031,39 +23164,589 @@
       "dev": true
     },
     "webpack": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
-      "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.4.1.tgz",
+      "integrity": "sha512-iLUJcsEAjaPKWbB32ADr29Pg9fPUVfFEMPK4VXyZGftzhSEFg2BLjHLoBYZ14wdTEA8xqG/hjpuX8qOmabRYvw==",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "async": "1.5.2",
-        "clone": "1.0.3",
-        "enhanced-resolve": "0.9.1",
-        "interpret": "0.6.6",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.3.0",
+        "acorn": "5.5.3",
+        "acorn-dynamic-import": "3.0.0",
+        "ajv": "6.4.0",
+        "ajv-keywords": "3.1.0",
+        "chrome-trace-event": "0.1.2",
+        "enhanced-resolve": "4.0.0",
+        "eslint-scope": "3.7.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "micromatch": "3.1.10",
         "mkdirp": "0.5.1",
-        "node-libs-browser": "0.7.0",
-        "optimist": "0.6.1",
-        "supports-color": "3.2.3",
-        "tapable": "0.1.10",
-        "uglify-js": "2.7.5",
-        "watchpack": "0.2.9",
-        "webpack-core": "0.6.9"
+        "neo-async": "2.5.0",
+        "node-libs-browser": "2.1.0",
+        "schema-utils": "0.4.5",
+        "tapable": "1.0.0",
+        "uglifyjs-webpack-plugin": "1.2.4",
+        "watchpack": "1.5.0",
+        "webpack-sources": "1.1.0"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+        "acorn": {
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         },
-        "interpret": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
-          "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls=",
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+          "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.5.3"
+          }
+        },
+        "ajv": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
           "dev": true
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+          "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+          "dev": true,
+          "requires": {
+            "pako": "1.0.6"
+          }
+        },
+        "chokidar": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.4"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+          "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+          "dev": true,
+          "requires": {
+            "browserify-cipher": "1.0.0",
+            "browserify-sign": "4.0.4",
+            "create-ecdh": "4.0.0",
+            "create-hash": "1.1.3",
+            "create-hmac": "1.1.6",
+            "diffie-hellman": "5.0.2",
+            "inherits": "2.0.3",
+            "pbkdf2": "3.0.14",
+            "public-encrypt": "4.0.0",
+            "randombytes": "2.0.6",
+            "randomfill": "1.0.4"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
+          "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "memory-fs": "0.4.1",
+            "tapable": "1.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
+          }
+        },
+        "https-browserify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+          "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "memory-fs": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+          "dev": true,
+          "requires": {
+            "errno": "0.1.7",
+            "readable-stream": "2.3.4"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        },
+        "node-libs-browser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+          "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+          "dev": true,
+          "requires": {
+            "assert": "1.4.1",
+            "browserify-zlib": "0.2.0",
+            "buffer": "4.9.1",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.12.0",
+            "domain-browser": "1.2.0",
+            "events": "1.1.1",
+            "https-browserify": "1.0.0",
+            "os-browserify": "0.3.0",
+            "path-browserify": "0.0.0",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "readable-stream": "2.3.4",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.8.0",
+            "string_decoder": "1.0.3",
+            "timers-browserify": "2.0.6",
+            "tty-browserify": "0.0.0",
+            "url": "0.11.0",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4"
+          }
+        },
+        "os-browserify": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+          "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+          "dev": true
+        },
+        "pako": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+          "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+          "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
+          "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
+          "dev": true
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz",
+          "integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
+          "dev": true,
+          "requires": {
+            "cacache": "10.0.4",
+            "find-cache-dir": "1.0.0",
+            "schema-utils": "0.4.5",
+            "serialize-javascript": "1.4.0",
+            "source-map": "0.6.1",
+            "uglify-es": "3.3.9",
+            "webpack-sources": "1.1.0",
+            "worker-farm": "1.6.0"
+          }
+        },
+        "watchpack": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
+          "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+          "dev": true,
+          "requires": {
+            "chokidar": "2.0.3",
+            "graceful-fs": "4.1.11",
+            "neo-async": "2.5.0"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          }
         }
       }
     },
@@ -23360,27 +24043,6 @@
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
-    "webpack-core": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
-      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
-      "dev": true,
-      "requires": {
-        "source-list-map": "0.1.8",
-        "source-map": "0.4.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
           }
         }
       }
@@ -24283,6 +24945,15 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
+    },
+    "worker-farm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.7"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "stylus-loader": "^3.0.0",
     "surge": "^0.20.0",
     "url-loader": "^0.6.0",
-    "webpack": "^1.13.2",
+    "webpack": "^4.0.0",
     "webpack-cli": "^2.0.13",
     "webpack-dev-server": "^3.0.0",
     "yamljs": "^0.3.0"


### PR DESCRIPTION
This Pull Request updates dependency [webpack](https://github.com/webpack/webpack) from `^1.13.2` to `^4.0.0`



<details>
<summary>Release Notes</summary>

### [`v2.2.0`](https://github.com/webpack/webpack/releases/v2.2.0)

### The first webpack 2 release

No changes here. It's equal to the last RC, but with an updated version number.

[Here](https://webpack.js.org/guides/migrating/) is a migration guide if you want to migrate from webpack 1 to webpack 2.

[Here](https://medium.com/webpack/webpack-2-2-the-final-release-76c3d43bf144) is a blog post about the release.

[Here](https://webpack.js.org/) is the documentation for webpack 2. It's new!

---

### [`v2.2.1`](https://github.com/webpack/webpack/releases/v2.2.1)

### Bugfixes:
- `ident` is no longer required, but it will choose one automatically
- DefinePlugin no longer generates invalid code when using nested objects without semicolons
### Features:
- You can provide defaults and silence warnings of the EnvironmentPlugin now

---

### [`v2.3.0`](https://github.com/webpack/webpack/releases/v2.3.0)

### Features:

* add `extensions` option to DllReferencePlugin
* add `warningsFilter` to UglifyJsPlugin to hide warnings selectively
* add `extractComments` to UglifyJsPlugin to move kept comments into separate file (i. e. LICENSE file)
* validate relative and absolute paths in configuration
* validate stats options
* allow to match on `compiler` (`name` in configuration) in rules
  * i. e. allows to specify different rules for `extract-text-webpack-plugin` or `html-webpack-plugin`
* Allow to pass multiple entries via CLI
* Performance improvements
* CommonsChunkPlugin give errors on incorrect options
* add `module.strictExportPresence` to make missing export an error instead of warning
* Compiler emits `watch-close` event when the watcher is closed
* Allow additional compress options in UglifyJsPlugin
* empty chunk numbers are not flags in every chunk, this improves caching invalidation
### Bugfixes:

* OccurrenceOrderPlugin now counts occurrences correctly
* Fix cheap-source-maps when combined with ES Modules (lines were offset)
* Watcher now detects file deleting correctly
* Resolve output path if relative output path is given via CLI
* Handle stack traces in errors correctly
* Some usages of `System` now generate valid code i. e. `System.global`
* Dynamic property names are now parsed and can contain webpack stuff (i. e. imports)
* Empty enviroment variables are now supported in the `EnvironmentPlugin`
* (Maybe) Fixes chunk loading in IE when script is cached
### Notes

The validation now fails when passing absolute paths with lowercase drive letter on windows.
(i. e. `c:\work\stuff` instead of `C:\work\stuff`)

Lowercase drive letters will cause weird errors (node.js behavior is inconsistent about drive letter casing) in some cases.

So please fix the paths in your shell resp. your tooling and always call webpack with uppercase drive letter. Don't use lowercase drive letters.

---

### [`v2.3.1`](https://github.com/webpack/webpack/releases/v2.3.1)

### Bugfixes:

* add stacktrace when calling `emitWarning/Error` from loader with non-Error value
* remove extra newline in absolute/relative path validation
* fix crash in MinChunkSizePlugin

---

### [`v2.3.2`](https://github.com/webpack/webpack/releases/v2.3.2)

### Bugfixes:

* Fix performance issue with cheap-source-maps
* Fix a line offset issue with cheap-source-maps
* Allow lowercased drive letters as absolute paths (not recommended)
* Improve some error reporting

---

### [`v2.3.3`](https://github.com/webpack/webpack/releases/v2.3.3)

### Bugfixes:

* fix progress in multi compiler

---

### [`v2.4.0`](https://github.com/webpack/webpack/releases/v2.4.0)

### Highlighted Features:
#### `import()` now allows to configure a chunk name

``` js
import(/* webpackChunkName: "my-chunk-name" */ "module")
```
#### `require.ensure` has a error callback

``` js
require.ensure([], () => {
    require("a");
}, err => {
    console.error("We failed to load chunk: " + err);
}, "chunk-name");
```
### Features:

* update to acorn 5
* resolve context is provided to resolver
* add `warningsFilter` to stats options to filter warnings
* add `__webpack_chunkname__` to `ExtendedAPIPlugin`
* support string chunk ids
* add `NamedChunksPlugin` which allows to set chunk id, i. e. to chunk name
* allow to provided different watch options for multiple compilations
* add error handler callback to `require.ensure`
* add chunk name option for `import()`
### Bugfixes:

* main flag for HMR is set correctly
* ignored modules are now context-agnositic
* recorded paths are now platform-agnositic
* fix for local AMD modules which wrap commonjs
* erros now print more detailed message when logged
* fix missing SourceMaps for non-entry chunks after rebuild
* variables now hoist in scope

---

### [`v2.4.1`](https://github.com/webpack/webpack/releases/v2.4.1)

### Bugfixes:

* Fix scope analysis in function declarations

---

### [`v2.5.0`](https://github.com/webpack/webpack/releases/v2.5.0)

### Bugfixes:

* add `hashSalt` to schema
* webpack's source code no longer contains `sourceMappingURL`, which caused issues with some tools
* Added missing semicolon in dll-imported modules
* DllPlugin manifest is smaller (not pretty printed)
* CommonsChunkPlugin in async mode doesn't extract from initial chunks
### Features:

* allow placeholders in the BannerPlugin
* add option to disable the module trace in stats

---

### [`v2.5.1`](https://github.com/webpack/webpack/releases/v2.5.1)

### Bugfixes:

* Fix crash when error happens while watching
* Fix hoisting of exports

---

### [`v2.6.0`](https://github.com/webpack/webpack/releases/v2.6.0)

### Features:

* add `webpackMode` comment option for `import()`
* add `output.chunkLoadTimeout`
### Bugfixes:

* fixed providing `webpackChunkName` for `import()` with expression
* fixed parsing of destructing in assignment
* fixed some edge cases when parsing declarations

---

### [`v2.6.1`](https://github.com/webpack/webpack/releases/v2.6.1)

### Bugfixes:

* Promise is now only needed when loading chunk, not in initialization
* variable injection in require.ensure is now working again
* better comment message when no export found (`output.pathinfo`)

---

### [`v3.0.0`](https://github.com/webpack/webpack/releases/v3.0.0)

### Changes from 2.6.1 to 3.0.0
#### Features

* `node_modules` no longer mangle to `~` in stats [breaking change]
* timeout for HMR requests is configurable
* added experimental Scope Hoisting (`webpack.optimize.ModuleConcatenationPlugin`)
* some performance improvements
* added `output.libraryExport` to select an export for the library
* `sourceMapFilename` now supports `[contenthash]` [breaking change]
* `module.noParse` supports functions
* add `node: false` option to disable all node specific additions
#### Bugfixes

* add workaround for breakpoints in eval source maps (chrome)
* avoid creating redundant connections in chunk graph
* enable chunk modules in stats by default
* add special behavior when using CommonsChunkPlugin with only `async` option
* error is shown when hot-only HMR fails
* fixed a few issues with weird stats output [breaking change]
* fixed a bug in occurrence order plugin [breaking change]
* optimization plugins now only affect the current compilation [breaking change]
* context now also include index files [breaking change]
* require.resolve evaluate truthy [breaking change]
* import order no longer adds to hash
* Hashing for RawModule fixed
#### Internal changes

* child compilations get records and cache assigned (they need a unique name) [breaking change]
* Set is used for Child.modules, Module.chunks, Reason.chunks [breaking change]
* uglifyjs-plugin is moved into separate repository
### Changes from 3.0.0-rc.2 to 3.0.0
#### Bugfixes

* fix duplicate dependencies in ConcatenatedModule
* Hashing for RawModule fixed
#### Internal changes

* uglifyjs-plugin is moved into separate repository

---

### [`v3.1.0`](https://github.com/webpack/webpack/releases/v3.1.0)

### Features:

* Allow different library names for UMD
* Support for passing a defined identifier as `this` in a IIFE
* Use the new resolve performance option `cacheWithContext: false` by default when it's safe
* Support array of functions as configuration
* add `sortModules` to `Chunk` which is required in extract-text-plugin to support webpack 3
### Bugfixes:

* `!` with truthy webpack identifier will evaluate correctly
* assets and dependencies are preserved in concatenated modules
* Fix some internal usage of deprecated APIs

---

### [`v3.2.0`](https://github.com/webpack/webpack/releases/v3.2.0)

### Bugfixes:

* fix duplicate entries in SourceMaps.
* call imported functions with correct context.
* support `strictThisContextOnImports` in ConcatenatedModules.
* fix a bug which prevents parsing arguments for imported function calls when using `strictThisContextOnImports`.
* support nested `.call()` renames of this.
* fix `typeof` with `require.resolve(Weak)`.
* fix hashing with ConcatenatedModules.

---

### [`v2.7.0`](https://github.com/webpack/webpack/releases/v2.7.0)

### Features:

* add `resolve.cacheWithContext` to schema
* add workaround for chrome with eval-source-maps
* update webpack-sources for performance reasons
* allow `[contenthash]` in `sourceMapFilename` as workaround for a caching bug

---

### [`v3.3.0`](https://github.com/webpack/webpack/releases/v3.3.0)

### Features:

* HMR logging now displays an expandable shorter module id.
### Bugfixes:

* Fix refactoring typo `this.compiler.compiler is not a function`
* NormalModule source can be cache between compilations (performance for incremental builds)
* webpack now also watches when missing directories are added (i. e. when a module was missing and is installed)

---

### [`v3.4.0`](https://github.com/webpack/webpack/releases/v3.4.0)

### Features:

* Improved optimization bailout messages
* NamedModulesPlugins and HashedModuleIdsPlugin work now properly with delegated modules (DllReferencePlugin) and externals.
* add `--config-name` option to choose a config by name for compiling a part of the config
* Improved error message when parsing in ModuleConcatenationPlugin fails
* Upgrade a lot of dependencies
* Child compilation names are not relative in stats
### Bugfixes:

* Fix setting boolean options in configuration (profile, bail)
* Fix "uncatched" exception in HMR runtime code
* Fix two cases where ModuleConcatenationPlugin crashes (missing internal name)
  * Concatating delegated modules (from Dlls)
  * reference to the default export of the root module
* Fix `--module-bind-pre` and `--module-bind-post`
### Performance:

* Performance improvements in 
  * SourceMapDevToolPlugin
  * AggressiveSplittingPlugin
  * NormalModule variable injection
  * Parser
  * RecordIdsPlugin
  * Stats

---

### [`v3.4.1`](https://github.com/webpack/webpack/releases/v3.4.1)

### Bugfixes:

* fix incorrect warnings about exports when using the DllReferencePlugin

---

### [`v3.5.0`](https://github.com/webpack/webpack/releases/v3.5.0)

### Features:

* add `stats.excludeAssets` to allow to filter assets in list (@&#8203;ldrick)
* add `import(/* webpackMode: "weak" */ "module")` to try to load a module without network request (@&#8203;faceyspacey)
* add 4. argument to `require.context` which is the context mode. Can be `false`, `"eager"`, `"lazy-once"`, `"weak"` and `"async-weak"`. (@&#8203;faceyspacey)
* `require.resolveWeak` now support expressions (@&#8203;faceyspacey)
* generate only a single require for modules references in scope-hoisted modules (`ModuleConcatenationPlugin`)
### Bugfixes:

* keep correct import order when using the `ModuleConcatenationPlugin`
* Generate shorter, more readable identifiers in `ConcatenatedModule`
* `--help` output is flushed before process exit (@&#8203;esbenp)
* exit code is reliable reported for CLI validation error (@&#8203;polomsky)
* `stats` options are now validated by schema (@&#8203;esbenp)
* fixes problem when using the `CommonsChunkPlugin` in async mode without `name` argument
* fixes description of `--resolve-extensions` (@&#8203;tomek-d)
* fixes `has no internal name` when using dependency variable in root of scope-hoisted modules (`ModuleConcatenationPlugin`)
### Examples:

* add an example for dll + app (@&#8203;aretecode)

---

### [`v3.5.1`](https://github.com/webpack/webpack/releases/v3.5.1)

### Bugfixes:

* fix invalid syntax when using non-number ids with Scope Hoisting

---

### [`v3.5.2`](https://github.com/webpack/webpack/releases/v3.5.2)

### Bugfixes:

* fixes stack overflow with circular dependencies (`ModuleConcatenationPlugin`)

---

### [`v3.5.3`](https://github.com/webpack/webpack/releases/v3.5.3)

### Bugfixes

* fixes a name conflict with the `ModuleConcatenationPlugin`

---

### [`v3.5.4`](https://github.com/webpack/webpack/releases/v3.5.4)

### Bugfixes

* Warnings and errors contribute to hash, which shows stats on warning-only change
* HMR: avoid crash when calling accept handler on disposed module
* HMR: disable Scope Hoisting for modules using HMR
* restore backwards compatibility of ConcatenatedModule (@&#8203;kisenka)
### Features:

* Add option to limit the number of parallel processed modules (`parallelism`)

---

### [`v3.5.5`](https://github.com/webpack/webpack/releases/v3.5.5)

### Bugfixes:

* fixes a bug where modules where incorrectly removed from chunks resulting in `call on undefined` errors (can happen when using `externals` and `CommonChunkPlugin`)
* Modules no longer loose `__esModule` flag on incremental build with `ModuleConcatenationPlugin`
* `__esModule` flag is now only set when needed with the `ModuleConcatenationPlugin`

---

### [`v3.5.6`](https://github.com/webpack/webpack/releases/v3.5.6)

### Bugfixes

* `--watch-poll` also accepts a number now (@&#8203;civalin)
* optimization bailout messages are now correctly cleared on incremental compilation (@&#8203;STRML)
* (back)slashes in querystring are not correctly handled when making the request relative to context (@&#8203;donocode)
* `orginalError` -> `originalError` in HMR API (@&#8203;sokra)
* fix `Cannot read property '0' of undefined` in harmony modules (@&#8203;sokra)
* Handle `require` to root of concatenated module correctly and don't generate `__webpack_require__(null)` (@&#8203;sokra)
* No longer use `async` as variable name (@&#8203;sokra)
* Object in options are now cloned when applying defaults (@&#8203;sokra)
### Performance

* Performance improvements for SourceMap devtool (@&#8203;filipesilva)

---

### [`v3.6.0`](https://github.com/webpack/webpack/releases/v3.6.0)

### Bugfixes

* Using folder names on CLI now correctly uses folder as entry (@&#8203;gyandeeps)
* Assign correct cache object to child compiler (@&#8203;sokra)

---

### [`v3.7.0`](https://github.com/webpack/webpack/releases/v3.7.0)

### Features

* Static analysis can now concat string with `.concat` (@&#8203;loganfsmyth)
* add `ContextExclusionPlugin` to exclude files in a context (@&#8203;timse)
* add `deepChildren` flag to `CommonChunkPlugin` (@&#8203;ArcEglos, @&#8203;ljcrapo)
* Allow using non-UMD externals combined with UMD externals (@&#8203;NMinhNguyen)
### Bugfixes

* References to dll now contribute correctly to hash (@&#8203;dtinth)
* fix behavior of `--watch-poll` in CLI (@&#8203;Aladdin-ADD)
* set `crossOrigin` on script tags for HMR (@&#8203;STRML)
* fix usage of local AMD modules in AMD require (@&#8203;chuckdumont)
* show a warning when using g or y flag for context RegExp (@&#8203;simon-paris)
* chunk graph should be now more correct (@&#8203;sokra)
### Performance

* fixes a performance problem with many ESM import/exports in a module (@&#8203;sokra)
* fixes a performance problem with heavily circular/interconnected chunks graphs (@&#8203;sokra)

---

### [`v3.7.1`](https://github.com/webpack/webpack/releases/v3.7.1)

### Bugfixes

* fix crash for undefined optional in ExternalModule (@&#8203;STRML)

---

### [`v3.8.0`](https://github.com/webpack/webpack/releases/v3.8.0)

### Features:

* It's now possible to include the `--env` data in stats (@&#8203;jbottigliero)
* There is a warning when trying to load a initial chunk with `import()` or `require.ensure` now (@&#8203;sokra)
### Bugfixes:

* fix a race condition for ENOENT errors (@&#8203;simon-paris)
* chunk reasons comments are now set more consistent (@&#8203;sokra)
* fix schema for `stats` and be more strict (@&#8203;jbottigliero)
  * This may lead to errors if you've provided wrong properties.
* remove the absolute path from the parser error message (@&#8203;sokra)
* fix changed behavior when loading a initial chunk on demand (@&#8203;sokra)
### Performance

* chunk graph is now build in breath-first traversal, which is faster (@&#8203;sokra)
* fix a performance problem in some edge cases (@&#8203;sokra)

---

### [`v3.8.1`](https://github.com/webpack/webpack/releases/v3.8.1)

### Bugfixes:

* add missing keys to `stats` schema for validation

---

### [`v3.9.0`](https://github.com/webpack/webpack/releases/v3.9.0)

### Features

* add more descriptions to the schema for better validation errors
* Handle arrow functions in AMD define/require
### Bugfixes

* added `stats.all` option to schema
* UMD uses `self` before `this` as global object
* Use `window` instead of this in JSONP
* handle `null` in SourceMap correctly
* Use Error name instead of instanceof to check for validation Error
* Respect node.js deprecation configuration for some deprecation messages in webpack
* Generate shorter identifiers for ConcatenatedModules to save memory
* fix increasing delay when using HMR with `multiStep: true`

---

### [`v3.9.1`](https://github.com/webpack/webpack/releases/v3.9.1)

### Bugfixes:

* add `ignored` and `stdin` to schema of `watchOptions`

---

### [`v3.10.0`](https://github.com/webpack/webpack/releases/v3.10.0)

### Features:

* add `publicPath` and `fileContext` to SourceMapDevToolPlugin
* `require.include` no longer uses all exports (Tree Shaking)

---

### [`v3.11.0`](https://github.com/webpack/webpack/releases/v3.11.0)

### Features

* Parser supports `new Foo` expressions
* Evaluator supports bitwise and exponential operator
* Many config options supporting placeholder now also support functions
* add `jsonpScriptType` to specify script type for lazy loaded script tags
* update ajv
### Bugfixes

* allow `ident` in schema
* `ident` is not lost when referencing by ident
* Prefer `process.exitCode` instead of `process.exit`
* workaround for bluebird warning in hot/signal
* Errors in child compilation now lead to global error
* Initial chunk are no longer part of the chunk manifest and no longer contribute to the hash
* don't crash on arrays with empty items
* workaround for node 8 and 9 bug while reading empty env values

---

### [`v4.0.0`](https://github.com/webpack/webpack/releases/v4.0.0)

### Big changes

* Environment
  * Node.js 4 is no longer supported. Source Code was upgraded to a higher ecmascript version.
* Usage
  * You have to choose (`mode` or `--mode`) between two modes now: production or development
    * production enables all kind of optimizations to generate optimized bundles
    * development enables comments and hint for development and enables the eval devtool
    * production doesn't support watching, development is optimized for fast incremental rebuilds
    * production also enables module concatenating (Scope Hoisting)
    * You can configure this in detail with the flags in `optimization.*` (build your custom mode)
    * `process.env.NODE_ENV` are set to production or development (only in built code, not in config)
    * There is a hidden `none` mode which disables everything
* Syntax
  * `import()` always returns a namespace object. CommonJS modules are wrapped into the default export
    * This probably breaks your code, if you used to import CommonJs with `import()`
* Configuration
  * You no longer need to use these plugins:
    * `NoEmitOnErrorsPlugin` -> `optimization.noEmitOnErrors` (on by default in production mode)
    * `ModuleConcatenationPlugin` -> `optimization.concatenateModules` (on by default in production mode)
    * `NamedModulesPlugin` -> `optimization.namedModules` (on by default in develoment mode)
  * `CommonsChunkPlugin` was removed -> `optimization.splitChunks`, `optimization.runtimeChunk`
* JSON
  * webpack now handles JSON natively
    * You may need to add `type: "javascript/auto"` when transforming JSON via loader to JS
    * Just using JSON without loader should still work
  * allows to import JSON via ESM syntax
    * unused exports elimination for JSON modules
* Optimization
  * Upgrade uglifyjs-webpack-plugin to v1
    * ES15 support
### Big features

* Modules
  * webpack now supports these module types:
    * javascript/auto: (The default one in webpack 3) Javascript module with all module systems enabled: CommonJS, AMD, ESM
    * javascript/esm: EcmaScript modules, all other module system are not available
    * javascript/dynamic: Only CommonJS and, EcmaScript modules are not available
    * json: JSON data, it's available via require and import
    * webassembly/experimental: WebAssembly modules (currently experimental)
  * `javascript/esm` handles ESM more strictly compared to `javascript/auto`:
    * Imported names need to exist on imported module
    * Dynamic modules (non-esm, i. e. CommonJs) can only imported via `default` import, everything else (including namespace import) emit errors
  * In `.mjs` modules are `javascript/esm` by default
  * WebAssembly modules
    * can import other modules (JS and WASM)
    * Exports from WebAssembly modules are validated by ESM import
      * You'll get a warning/error when trying to import a non-existing export from WASM
    * can only be used in async chunks. They doesn't work in initial chunks (would be bad for web performance)
      * Import modules using WASM via `import()`
    * This is an experimental feature and subject of change
* Optimization
  * `sideEffects: false` is now supported in package.json
    * `sideEffects` in package.json also supports glob expressions and arrays of glob expressions
  * Instead of a JSONP function a JSONP array is used -> async script tag support, order no longer matter
  * New `optimization.splitChunks` option was introduced
    Details: https://gist.github.com/sokra/1522d586b8e5c0f5072d7565c2bee693
  * Dead branches are now removed by webpack itself
    * Before: Uglify removed the dead code
    * Now: webpack removes the dead code (in some cases)
    * This prevents crashing when `import()` occur in a dead branch
* Syntax
  * `webpackInclude` and `webpackExclude` are supported by the magic comment for `import()`. They allow to filter files when using a dynamic expression.
  * Using `System.import()` now emits a warning
    * You can disable the warning with `Rule.parser.system: true`
    * You can disable `System.import` with `Rule.parser.system: false`
* Configuration
  * Resolving can now be configured with `module.rules[].resolve`. It's merged with the global configuration.
  * `optimization.minimize` has been added to switch minimizing on/off
    * By default: on in production mode, off in development mode
  * `optimization.minimizer` has been added to configurate minimizers and options
* Usage
  * Some Plugin options are now validated
  * CLI has been move to webpack-cli, you need to install `webpack-cli` to use the CLI
  * The ProgressPlugin (`--progress`) now displays plugin names
    * At least for plugins migrated to the new plugin system
* Performance
  * UglifyJs now caches and parallizes by default
  * Multiple performance improvements, especially for faster incremental rebuilds
  * performance improvement for RemoveParentModulesPlugin
* Stats
  * Stats can display modules nested in concatenated modules
### Features

* Configuration
  * Module type is automatically choosen for mjs, json and wasm extensions. Other extensions need to be configured via `module.rules[].type`
  * Incorrect `options.dependencies` configurations now throw error
  * `sideEffects` can be overriden via module.rules
  * `output.hashFunction` can now be a Constructor to a custom hash function
    * You can provide a non-cryto hash function for performance reasons
  * add `output.globalObject` config option to allow to choose the global object reference in runtime exitCode
* Runtime
  * Error for chunk loading now includes more information and two new properties `type` and `request`.
* Devtool
  * remove comment footer from SourceMaps and eval
  * add support for `include` `test` and `exclude` to the eval source map devtool plugin
* Performance
  * webpacks AST can be passed directly from loader to webpack to avoid extra parsing
  * Unused modules are no longer unnecessarly concatenated
  * Add a ProfilingPlugin which write a (Chrome) profile file which includes timings of plugins
  * Migrate to using `for of` instead of `forEach`
  * Migrate to using `Map` and `Set` instead of Objects
  * Migrate to using `includes` instead of `indexOf`
  * Replaced some RegExp with string methods
  * Queue don't enqueues the same job twice
  * Use faster md4 hash for hashing by default
* Optimization
  * When using more than 25 exports mangled export names are shorter.
  * script tags are no longer `text/javascript` and `async` as this are the default values (saves a few bytes)
  * The concatenated module now generates a bit less code
  * constant replacements now don't need `__webpack_require__` and argument is omitted
* Defaults
  * webpack now looks for the `.wasm`, `.mjs`, `.js` and `.json` extensions in this order
  * `output.pathinfo` is now on by default in develoment mode
  * in-memory caching is now off by default in production
  * `entry` defaults to `./src`
  * `output.path` defaults to `./dist`
  * Use `production` defaults when omiting the `mode` option
* Usage
  * Add detailed progress reporting to SourceMapDevToolPlugin
  * removed plugins now give a useful error message
* Stats
  * Sizes are now shown in kiB instead of kB in Stats
  * entrypoints are now shows by default in Stats
  * chunks now display `<{parents}>` `>{children}<` and `={siblings}=` in Stats
  * add `buildAt` time to stats
  * stats json now includes the output path
* Syntax
  * A resource query is supported in context
  * Referencing entry point name in `import()` now emits a error instead of a warning
  * Upgraded to acorn 5 and support ES 2018
* Plugins
  * `done` is now an async hook
### Bugfixes

* Generated comments no longer break on `*/`
* webpack no longer modifies the passed options object
* Compiler "watch-run" hook now has the Compiler as first parameter
* add `output.chunkCallbackName` to the schema to allow configurating WebWorker template
* Using `module.id/loaded` now correctly bails out of Module Concatentation (Scope Hoisting)
* OccurenceOrderPlugin now sorts modules in correct order (instead of reversed)
* timestamps for files are read from watcher when calling `Watching.invalidate`
* fix incorrect `-!` behavior with post loaders
* add `run` and `watchRun` hooks for `MultiCompiler`
* `this` is now undefined in ESM
* VariableDeclaration are correctly identified as `var`, `const` or `let`
* Parser now parse the source code with the correct source type (module/script) when the module type `javascript/dynamic` or `javascript/module` is used.
* don't crash on missing modules with `buildMeta` of null
* add `original-fs` module for electron targets
* HMRPlugin can be added to the Compiler outside of `plugins`
### Internal changes

* Replaced `plugin` calls with `tap` calls (new plugin system)
* Migrated many deprecated plugins to new plugin system API
* added `buildMeta.exportsType: "default"` for json modules
* Remove unused methods from Parser (parserStringArray, parserCalculatedStringArray)
* Remove ability to clear BasicEvaluatedExpression and to have multiple types
* Buffer.from instead of new Buffer
* Avoid using forEach and use for of instead
* Use `neo-async` instead of `async`
* Update tapable and enhanced-resolve dependencies to new major versions
* Use prettier
### Removed features

* removed `module.loaders`
* removed `loaderContext.options`
* removed `Compilation.notCacheable` flag
* removed `NoErrorsPlugin`
* removed `Dependency.isEqualResource`
* removed `NewWatchingPlugin`
* removed `CommonsChunkPlugin`
### Breaking changes for plugins/loaders

* new plugin system
  * `plugin` method is backward-compatible
  * Plugins should use `Compiler.hooks.xxx.tap(<plugin name>, fn)` now
* New major version of enhanced-resolve
* Templates for chunks may now generate multiple assets
* `Chunk.chunks/parents/blocks` are no longer Arrays. A Set is used internally and there are methods to access it.
* `Parser.scope.renames` and `Parser.scope.definitions` are no longer Objects/Arrays, but Map/Sets.
* Parser uses `StackedSetMap` (LevelDB-like datastructure) instead of Arrays
* `Compiler.options` is no longer set while applying plugins
* Harmony Dependencies has changed because of refactoring
* `Dependency.getReference()` may now return a `weak` property. `Dependency.weak` is now used by the `Dependency` base class and returned in the base impl of `getReference()`
* Constructor arguments changed for all `Module`s
* Merged options into options object for `ContextModule` and `resolveDependencies`
* Changed and renamed dependencies for `import()
* Moved `Compiler.resolvers` into `Compiler.resolverFactory` accessible with plugins
* `Dependency.isEqualResource` has been replaced with `Dependency.getResourceIdentifier`
* Methods on `Template` are now static
* A new RuntimeTemplate class has been added and `outputOptions` and `requestShortener` has been moved to this class
  * Many methods has been updated to use the RuntimeTemplate instead
  * We plan to move code which accesses the runtime to this new class
* `Module.meta` has been replaced with `Module.buildMeta`
* `Module.buildInfo` and `Module.factoryMeta` have been added
* Some properties of `Module` have been moved into the new objects
* added `loaderContext.rootContext` which points to the `context` options. Loaders may use it to make stuff relative to the application root.
* add `this.hot` flag to loader context when HMR is enabled
* `buildMeta.harmony` has been replaced with `buildMeta.exportsType: "namespace`
* The chunk graph has changed:
  * Before: Chunks were connected with parent-child-relationships.
  * Now: ChunkGroups are connected with parent-child-relationships. ChunkGroups contain Chunks in order.
  * Before: AsyncDependenciesBlocks reference a list of Chunks in order.
  * Now: AsyncDependenciesBlocks reference a single ChunkGroup.
* file/contextTimestamps are Maps now
* `map/foreach` `Chunks/Modules/Parents` methods are now deprecated/removed
* NormalModule accept options object in Constructor
* Added required generator argument for NormalModule
* Added `createGenerator` and `generator` hooks for NormalModuleFactory to customize code generation
* Allow to customize render manifest for Chunks via hooks

---

### [`v4.0.1`](https://github.com/webpack/webpack/releases/v4.0.1)

### Features

* add `version` property to webpack exports
### Bugfixes

* `import()` with CJS now gives correct exports
* Module concatenation bailout messages now point to correct module

---

### [`v4.1.0`](https://github.com/webpack/webpack/releases/v4.1.0)

### Features

* add `filename` option to `optimization.splitChunks` to modify the filename template for splitted chunks
* allow modules which doesn't emit code into the bundle
### Bugfixes

* watchpack updated to 1.5.0
* performance fix for Module Concatenation (v8 bug)
* fix using `this.xxx` in `ProvidePlugin`

---

### [`v4.1.1`](https://github.com/webpack/webpack/releases/v4.1.1)

### Features

* Stats now displays the number of assets of a module
### Bugfixes

* `sourceMap` option of the default UglifyJsPlugin now defaults to true when the SourceMapDevToolPlugin is used
* `module.assets` is now working again in the Stats
* chunk ids are not stringified on target node
* `devtoolNamespace` default works now also for arrays passed to `output.library`
* Format date with 2 digits in Stats for Build At 
* fix a bug renaming classes incorrectly
* fix a bug where modules ignore the `chunks` option of `optimization.splitChunks`

---

### [`v4.2.0`](https://github.com/webpack/webpack/releases/v4.2.0)

### Features

* add `splitChunks.automaticNameDelimiter` to configure the name separator for automatic names
* `stats.excludeModules` now also accept booleans
* webpack throws an error when trying to run in twice at a time
* `performance` is disabled by default in non-web targets
* AMD parser plugins can now be extended by inheriting
### Bugfixes

* Fix a race condition when writing `events.json` in ProfilingPlugin
* HMR runtime code is reverted to ES5 style
* script timeout is not correctly in seconds
* reexporting JSON exports works correctly now
* fix a bug when combining ProfilingPlugin with SourceMapDevToolPlugin
* add a missing semicolon to the runtime code

---

### [`v4.3.0`](https://github.com/webpack/webpack/releases/v4.3.0)

### Features

* add support for `[contenthash]` placeholder
### Bugfixes

* `browser` field is used for target `electron-renderer`
* set `devtoolNamespace` default correctly when passing an object to `output.library`

---

### [`v4.4.0`](https://github.com/webpack/webpack/releases/v4.4.0)

### Features

* When webpack-cli is not installed it will ask to install it
* `splitChunks.chunks` supports a custom function now
* Better warning when omitting `mode`
### Bugfixes

* disallow functions for `chunkFilename`, because it's not working
* generate correct code when using `export default (function xxx() {})`
### Performance

* Performance improvements for sorting by identifier

---

### [`v4.4.1`](https://github.com/webpack/webpack/releases/v4.4.1)

### Bugfixes

* fix yarn/npm install script on windows

---

### [`v4.5.0`](https://github.com/webpack/webpack/releases/v4.5.0)

### Features

* Performance improvements
* Improve readablility of error messages with long loader string
### Bugfixes

* Sort child compilations for consistent compilation hash
* Fix bug causing all symbols to be renamed when concatenating modules
### Contributing

* add `yarn setup` script for bootstrapping local development

---

</details>


<details>
<summary>Commits</summary>

#### v4.3.0
-   [`fc2feaf`](https://github.com/webpack/webpack/commit/fc2feaf6d7bb2929205f9ed150a564c75feddcf1) Merge pull request #&#8203;6844 from swederik/issue-6843
-   [`f1092ad`](https://github.com/webpack/webpack/commit/f1092ad516b77b763a5797e155b24ce0d37bd96b) Update prettier toolchain
-   [`1677144`](https://github.com/webpack/webpack/commit/1677144fafadd7c3ce4f3fe6b2aee689387945c7) Allow filter function in `optimization.splitChunks.cacheGroups[name].chunks`
-   [`a31bf26`](https://github.com/webpack/webpack/commit/a31bf266c19885cd4895296e9fb3a9d58a3e077c) fix capitalization of project name in README.md
-   [`165a2ed`](https://github.com/webpack/webpack/commit/165a2edf1692799de040c28367a21c3b2e40b3a3) Remove extraneous argument from setOptions call sites in OptionsDefaulter
-   [`df2b3c2`](https://github.com/webpack/webpack/commit/df2b3c2186d08e8f755271058488c4657f573aa6) Prettier
-   [`3691224`](https://github.com/webpack/webpack/commit/3691224689392c176e727ef238277b74a1ac75ec) Merge pull request #&#8203;6872 from boneskull/patch-1
-   [`d762a2b`](https://github.com/webpack/webpack/commit/d762a2b733b3cb557a83bc5964d37edfd0fa4584) Merge pull request #&#8203;6875 from mohsen1/patch-2
-   [`54ceb3c`](https://github.com/webpack/webpack/commit/54ceb3c04d513ef5c7b78eaf4d391d14cfbe8282) 4.3.0
#### v4.4.0
-   [`a7654fb`](https://github.com/webpack/webpack/commit/a7654fb2814a9e1cbb03b87848f960d00922f84a) Remove extra argument passed to JavascriptGenerator constructor
-   [`3e04ace`](https://github.com/webpack/webpack/commit/3e04ace60c1fbf85dab5b7241a04daf2472a4d97) Remove extra argument from WebAssemblyImportDependency constructor call site
-   [`847bfa4`](https://github.com/webpack/webpack/commit/847bfa4c6379679540df02e4fae3da6c838d454a) Remove dead code in Compilation.js
-   [`9309e85`](https://github.com/webpack/webpack/commit/9309e85f0f9668e13d33b9df232da658003446c9) Initialize loc member in Dependency
-   [`864a159`](https://github.com/webpack/webpack/commit/864a15977feb6c7e9f85515dd02978ce6e378dbb) Remove extra arguments passed to SortableSet initializing  fileDependencies
-   [`d2dbed5`](https://github.com/webpack/webpack/commit/d2dbed5dda34082745a6add5c47fe9ee71eea218) Update Compilation.js
-   [`81b93e2`](https://github.com/webpack/webpack/commit/81b93e262f811186aefc138ab4491335a36019d1) Initialize useSourceMap in Module
-   [`5146ee5`](https://github.com/webpack/webpack/commit/5146ee55e6595c5fe8c69e9f5cd3c511f7da97e9) Don&#x27;t detect exportDeclaration when named function expression
-   [`3c699eb`](https://github.com/webpack/webpack/commit/3c699eb1f85ab0aba6f4dccbfa4292ae399c46ad) oops
-   [`6f8b281`](https://github.com/webpack/webpack/commit/6f8b281bf4d7c598b6dc87a9ec00c58b4c084921) make prettier
-   [`628c33c`](https://github.com/webpack/webpack/commit/628c33c5b099d2577472579b2afca29accbaac97) Merge pull request #&#8203;6886 from mohsen1/init-useSourcemap
-   [`46de110`](https://github.com/webpack/webpack/commit/46de1107aa279199fc90cc4f9aa8e0e21bb9dcc7) Merge pull request #&#8203;6884 from mohsen1/initialize-loc
-   [`daca9cb`](https://github.com/webpack/webpack/commit/daca9cbc186c4107e15b08d0b3e9f16f6fe9b647) expand
-   [`2e43e8c`](https://github.com/webpack/webpack/commit/2e43e8c99817c2a116e7d0a5463b70f027b89d9b) This really should be part of another PR
-   [`2b7ab5d`](https://github.com/webpack/webpack/commit/2b7ab5d41fea1fc49f6d1e18cea367c8a38b3c8a) fix: better no mode warning message
-   [`1914f83`](https://github.com/webpack/webpack/commit/1914f836341369d232d75cef8b2503c2682cb4b1) chore: prettify files
-   [`93a5bf5`](https://github.com/webpack/webpack/commit/93a5bf567fe73d81b447384259eb9a4c6d0baa26) fixes for mini-css-extract-plugin
-   [`3b3779d`](https://github.com/webpack/webpack/commit/3b3779d7f1e6081fe533d7506bf8245116d5a84f) move to cases
-   [`9310cea`](https://github.com/webpack/webpack/commit/9310cea48094a0dab7efe33d6b3903ef60be5dda) test: update expected terminal output
-   [`bc76fee`](https://github.com/webpack/webpack/commit/bc76fee70b8d21cab81916a974ece6f27e42f760) Initialize compilationDependencies in Compilation as undefined
-   [`9728f2d`](https://github.com/webpack/webpack/commit/9728f2d2e02f3a385d4f22e2faaecd2aad9ebfd3) Revert &quot;Remove dead code in Compilation.js&quot;
-   [`77535dd`](https://github.com/webpack/webpack/commit/77535dde7cd3f1e1731276203e2b5205ca317c6c) Initialize fileTimestamps and contextTimestamps in Compilation
-   [`17034eb`](https://github.com/webpack/webpack/commit/17034eb61cd70248bf6c1ccbc20d0c6dbe3a34b1) Merge pull request #&#8203;6892 from jeremenichelli/clearer-mode-warning
-   [`c148089`](https://github.com/webpack/webpack/commit/c1480892cb58296deb31eea31d138e804c501884) Merge pull request #&#8203;6881 from mohsen1/patch-3
-   [`8498fc0`](https://github.com/webpack/webpack/commit/8498fc091e5375c7c41630723e8fa7916fcc1511) Merge pull request #&#8203;6885 from mohsen1/patch-5
-   [`5e0b2ba`](https://github.com/webpack/webpack/commit/5e0b2baed2bbf0007c0931fba845d2615b9d4a8d) Pretty!
-   [`7a72ee9`](https://github.com/webpack/webpack/commit/7a72ee92c007f6fa27d48fa29ce45797d5cff0e1) Merge branch &#x27;master&#x27; of github.com:webpack/webpack into remove-dead-code
-   [`6fa6720`](https://github.com/webpack/webpack/commit/6fa6720abcb3e6f07d29a5ba4bc4710bfc7b4f8d) Intialize start and end time as undefined in Stats
-   [`d6b2515`](https://github.com/webpack/webpack/commit/d6b2515e0c90cea2159ee04d70f830af123c6815) Remove extra argument passed to ContextModuleFactory in Compiler
-   [`77afc92`](https://github.com/webpack/webpack/commit/77afc92c5f5e4576ca4f767bd256d060f7103c9d) Remove extra argument sent to HarmonyExportExpressionDependencyConcatenatedTemplate
-   [`fe72829`](https://github.com/webpack/webpack/commit/fe728290e9fa82a8abb1d2ccd462bb0c2c57d59a) Remove extra argument passed to getEntrypointSize in SizeLimitsPlugin
-   [`fdc4f9f`](https://github.com/webpack/webpack/commit/fdc4f9f0f0ecbdd7ec4f8ca2398747bffaf38b6d) copy+paste typo
-   [`eae62bf`](https://github.com/webpack/webpack/commit/eae62bf82331b0aaead2dde0928122badbc6fa14) Merge pull request #&#8203;6900 from mohsen1/patch-8
-   [`ca79190`](https://github.com/webpack/webpack/commit/ca7919028571cbd90fb3ea58038565edd7f0b6df) Merge pull request #&#8203;6899 from mohsen1/patch-7
-   [`cc77f7e`](https://github.com/webpack/webpack/commit/cc77f7e999938c54d7114cb1034bc0b834d24e71) Merge pull request #&#8203;6898 from mohsen1/patch-6
-   [`e15df70`](https://github.com/webpack/webpack/commit/e15df707388c16d45cbf5f83936b22d95f1f92e8) Merge pull request #&#8203;6897 from mohsen1/init-time
-   [`4b6ee73`](https://github.com/webpack/webpack/commit/4b6ee7356dd119b44e9c8063b09cc2056283234a) Merge pull request #&#8203;6894 from webpack/bugfix/css-stuff
-   [`1e7cc39`](https://github.com/webpack/webpack/commit/1e7cc390d5beda329d19fb2c4821fd70f45fd369) Merge pull request #&#8203;6889 from Janpot/issue-6867
-   [`d4f3c77`](https://github.com/webpack/webpack/commit/d4f3c775d534c11ed6e8aff5f6f685fa7309e766) Merge pull request #&#8203;6883 from mohsen1/remove-dead-code
-   [`3a6edf0`](https://github.com/webpack/webpack/commit/3a6edf0377e7e4fe5182517fa075d2ec8f434bb8) Merge pull request #&#8203;6882 from mohsen1/patch-4
-   [`1b50e4e`](https://github.com/webpack/webpack/commit/1b50e4e96d32f86f47cec8240198bec928e3fae0) Merge pull request #&#8203;6833 from webpack/ellipsis
-   [`f600ccd`](https://github.com/webpack/webpack/commit/f600ccd2642aa8852e26c94ec42b5812e1801ea1) Merge pull request #&#8203;6827 from Connormiha/optimize-sort-by-identifier
-   [`b30de38`](https://github.com/webpack/webpack/commit/b30de38eb5311051388db05287aa3fd951fa41de) Merge pull request #&#8203;6672 from EugeneHlushko/fix/6639
-   [`3f6b78f`](https://github.com/webpack/webpack/commit/3f6b78f260db11d6c2533f165c4a4ed2595da3d8) Merge pull request #&#8203;6467 from PlayMa256/prompt_install_cli
-   [`0f70fcb`](https://github.com/webpack/webpack/commit/0f70fcb99f56857dbb7bcdffd06080bc9b0ee05c) Merge pull request #&#8203;6791 from storybooks/spilt-chunks-selector
-   [`8d8da4c`](https://github.com/webpack/webpack/commit/8d8da4cdff72bd035645ff44aa2f7aa4231292e7) Merge branch &#x27;master&#x27; into bump_prettier
-   [`2bd495c`](https://github.com/webpack/webpack/commit/2bd495cec1a57c8defae1e61b42718f251944eee) Merge pull request #&#8203;6864 from webpack/bump_prettier
-   [`65aa1c0`](https://github.com/webpack/webpack/commit/65aa1c09288385014a5dc4b5911717a13a5346cc) format the file path in the error message
-   [`e3bb8c9`](https://github.com/webpack/webpack/commit/e3bb8c9c8f5a30884b4df01bfbbc772cc1fb8cda) 4.4.0
#### v4.4.1
-   [`30c35ab`](https://github.com/webpack/webpack/commit/30c35abb44bdc6da4c0093f4cd144e8af5313cfb) use shell mode for windows support
-   [`26c0c60`](https://github.com/webpack/webpack/commit/26c0c60679b68845a48b8cd50818b6052a7ec87b) Merge pull request #&#8203;6907 from webpack/bugfix/cli-windows
-   [`0e404b8`](https://github.com/webpack/webpack/commit/0e404b8683d79052e3a6b42743bd3061f17a5a5d) 4.4.1
#### v4.5.0
-   [`10d6067`](https://github.com/webpack/webpack/commit/10d60678183d4bd7901e61fb34ad4cfde95ed907) Use a Map for dependencyTemplatesHashMap instead of a WeakMap
-   [`10ff2c3`](https://github.com/webpack/webpack/commit/10ff2c3b3f4ae78f4bdf95ade65da2a4a0f04bbd) Consolidate eslint config in one file.
-   [`ae88961`](https://github.com/webpack/webpack/commit/ae88961fb2efccaf9fb3e716894651302af2ca60) Remove unneeded eslint config for `hot` directory.
-   [`69d3548`](https://github.com/webpack/webpack/commit/69d354835c70e92a06f272d4a5a07a57c9729507) Add `browser` env to all browser facing files.
-   [`4c47b10`](https://github.com/webpack/webpack/commit/4c47b1035f63e7f686ad04038f68f606b09f15d2) package-lock.json added to .gitignore
-   [`4ae95a6`](https://github.com/webpack/webpack/commit/4ae95a68920c84b072c708d4ccfd4430caf86f68) Add HideStackError class for errors that have hideStack &#x3D; true
-   [`33e626e`](https://github.com/webpack/webpack/commit/33e626e2d041a486c5baadd9702e0281fb8c8c23) added file .npmrc  --&gt; package-lock&#x3D;false
-   [`8de5605`](https://github.com/webpack/webpack/commit/8de560552ceb1b690d04a5e948a9fa00aeebde53) sort child compilations for consitent hash
-   [`33166f2`](https://github.com/webpack/webpack/commit/33166f2d83065d0949e3481e0a9e3d47a74b1076) Merge pull request #&#8203;6928 from alberto/eslint-config-overrides
-   [`2fa104f`](https://github.com/webpack/webpack/commit/2fa104f73a78890162186a87708110e3eec33d1a) avoid walking scopes multiple times for performance reasons
-   [`3e49fcd`](https://github.com/webpack/webpack/commit/3e49fcd0a9c22a9410b9afbb4e9abdd1f42061b7) CR feedback
-   [`9abfd87`](https://github.com/webpack/webpack/commit/9abfd87e0d3a936b4ed4b80abdcbfe350a6fac95) Merge branch &#x27;master&#x27; of github.com:webpack/webpack into map-not-weakmap
-   [`7bc38d4`](https://github.com/webpack/webpack/commit/7bc38d4bf416a1d54367bcaeba3cc230e4010831) CR feedback
-   [`d077eda`](https://github.com/webpack/webpack/commit/d077eda3317a7077a9c32c476e39bd1236dea6ce)  lint
-   [`eebf086`](https://github.com/webpack/webpack/commit/eebf0866a996fa7d1ace4b888cd1a0fce8a032f3) Use correct function arity
-   [`8570165`](https://github.com/webpack/webpack/commit/8570165c1f8f00a7a513f2b4f8ce54e0af7404c4) Use a class for dependency references
-   [`97c6703`](https://github.com/webpack/webpack/commit/97c6703aab3dbb2f336f893aada9c105b3ea0cc7) Make &#x27;getReference&#x27; monomorphic
-   [`0596346`](https://github.com/webpack/webpack/commit/0596346dbc0b73c4e81eac80ecba9bed44d30dab) Always pass first argument of &#x27;getMode&#x27;
-   [`148a593`](https://github.com/webpack/webpack/commit/148a5935dc25b761595a36f03a9dca5e95313442) Merge pull request #&#8203;6952 from webpack/refactor/reference_deopt
-   [`24a5699`](https://github.com/webpack/webpack/commit/24a5699f3985b613566a1f8c68467c0b777a7fa9) Remove extraneous debug statement
-   [`fe55ceb`](https://github.com/webpack/webpack/commit/fe55ceb2fea7c9cd425690c409880338a31d8a39) Keep super.apply call
-   [`e65751a`](https://github.com/webpack/webpack/commit/e65751ac6f838306032524fd0a921494cbb83453) Merge pull request #&#8203;6932 from mohsen1/hideStack
-   [`ed5b541`](https://github.com/webpack/webpack/commit/ed5b5413f0ab6ab096a4d5e1553abbdbf09c09ed) Merge pull request #&#8203;6930 from Legends/gitignorePatch
-   [`f1993f4`](https://github.com/webpack/webpack/commit/f1993f45759db2a8e7d202686fa6a8d0331194dd) Merge pull request #&#8203;6922 from mohsen1/map-not-weakmap
-   [`1958784`](https://github.com/webpack/webpack/commit/19587844336222f9f239550c42a1fc87959fa25a) Merge pull request #&#8203;6904 from webpack/performance/concat
-   [`83b99b9`](https://github.com/webpack/webpack/commit/83b99b9edd4faf9208cf0cd313ed8606f083dfe4) add setup script and update package scripts
-   [`f3c9bd0`](https://github.com/webpack/webpack/commit/f3c9bd01b942a64707752f48d974f2d4c2acf512) Merge pull request #&#8203;6953 from webpack/refactor/mode_deopt
-   [`b6042fb`](https://github.com/webpack/webpack/commit/b6042fb9371fc297e9677cd7916963cd21ef1fc4) Prevent identToLoaderRequest to return 2 objects with different shapes
-   [`5c8a4bb`](https://github.com/webpack/webpack/commit/5c8a4bb89f6f741511bef98cdab3d84e9759c72a) Unify Dependency#getExports result
-   [`a5ae054`](https://github.com/webpack/webpack/commit/a5ae054b1e64bbf692c8c6ebd8163744cf22fb33) Ensure the type of the binding don&#x27;t change
-   [`9f5c1b4`](https://github.com/webpack/webpack/commit/9f5c1b4cf934823f5c117628ed10e10ba5e84890) Merge pull request #&#8203;6951 from webpack/fix/arity
-   [`a8d70e7`](https://github.com/webpack/webpack/commit/a8d70e7d19f752613f6edfe9717de42c3b0fc2b3) Merge pull request #&#8203;6955 from webpack/Legends-webpack-bootstrap-setup
-   [`45e7f7a`](https://github.com/webpack/webpack/commit/45e7f7a2cb95b1839e2165ea39b98d87c7f65e04) Merge pull request #&#8203;6878 from rchaser53/fix-options-loader-error
-   [`3f33d88`](https://github.com/webpack/webpack/commit/3f33d888601f1d448ab921b0964b771f10b7a4f7) Merge pull request #&#8203;6943 from webpack/bugfix/sort-children-for-hash
-   [`27d7668`](https://github.com/webpack/webpack/commit/27d76683a3917031e47d7d4d2336ef203bc4663c) align stats string output to max length
-   [`e717fcc`](https://github.com/webpack/webpack/commit/e717fcc6a1f2a9133a8ed960ac3d0102864a6428) Merge pull request #&#8203;6956 from webpack/refactor/share_shapes
-   [`e400445`](https://github.com/webpack/webpack/commit/e400445445a2f91d19aa8c79aa7b34b66011e661) 4.5.0
-   [`f5bd213`](https://github.com/webpack/webpack/commit/f5bd213f4c697259106da528eb9af1d1bb9c8ba3) Update examples

</details>