### PR TITLE
chore(deps): update dependency react to ^16.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19308,11 +19308,10 @@
       }
     },
     "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
+      "integrity": "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
       "requires": {
-        "create-react-class": "15.6.3",
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "faker": "^4.0.0",
     "lodash": "^4.16.2",
     "netlify-lambda": "^0.3.0",
-    "react": "^15.4.0",
+    "react": "^16.0.0",
     "react-dom": "^15.3.1",
     "whatwg-fetch": "^2.0.0"
   },


### PR DESCRIPTION
This Pull Request updates dependency [react](https://github.com/facebook/react) from `^15.4.0` to `^16.0.0`



<details>
<summary>Release Notes</summary>

### [`v16.0.0`](https://github.com/facebook/react/blob/master/CHANGELOG.md#&#8203;1600-September-26-2017)

##### New JS Environment Requirements

 * React 16 depends on the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set), as well as [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame). If you support older browsers and devices which may not yet provide these natively (e.g. <IE11), [you may want to include a polyfill](https://gist.github.com/gaearon/9a4d54653ae9c50af6c54b4e0e56b583).
##### New Features
* Components can now return arrays and strings from `render`. (Docs coming soon!)
* Improved error handling with introduction of "error boundaries". [Error boundaries](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html) are React components that catch JavaScript errors anywhere in their child component tree, log those errors, and display a fallback UI instead of the component tree that crashed.
* First-class support for declaratively rendering a subtree into another DOM node with `ReactDOM.createPortal()`. (Docs coming soon!)
* Streaming mode for server side rendering is enabled with `ReactDOMServer.renderToNodeStream()` and `ReactDOMServer.renderToStaticNodeStream()`. ([@&#8203;aickin] in [#&#8203;10425](`https://github.com/facebook/react/pull/10425`), [#&#8203;10044](`https://github.com/facebook/react/pull/10044`), [#&#8203;10039](`https://github.com/facebook/react/pull/10039`), [#&#8203;10024](`https://github.com/facebook/react/pull/10024`), [#&#8203;9264](`https://github.com/facebook/react/pull/9264`), and others.)
* [React DOM now allows passing non-standard attributes](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html). ([@&#8203;nhunzaker] in [#&#8203;10385](`https://github.com/facebook/react/pull/10385`), [10564](`https://github.com/facebook/react/pull/10564`), [#&#8203;10495](`https://github.com/facebook/react/pull/10495`) and others)
##### Breaking Changes
- There are several changes to the behavior of scheduling and lifecycle methods:
  * `ReactDOM.render()` and `ReactDOM.unstable_renderIntoContainer()` now return `null` if called from inside a lifecycle method.
    * To work around this, you can either use [the new portal API](`https://github.com/facebook/react/issues/10309`#issuecomment-318433235) or [refs](`https://github.com/facebook/react/issues/10309`#issuecomment-318434635).
  * Minor changes to `setState` behavior:
    * Calling `setState` with null no longer triggers an update. This allows you to decide in an updater function if you want to re-render.
    * Calling `setState` directly in render always causes an update. This was not previously the case. Regardless, you should not be calling `setState` from render.
    * `setState` callback (second argument) now fires immediately after `componentDidMount` / `componentDidUpdate` instead of after all components have rendered.
  * When replacing `<A />` with `<B />`,  `B.componentWillMount` now always happens before  `A.componentWillUnmount`. Previously, `A.componentWillUnmount` could fire first in some cases.
  * Previously, changing the `ref` to a component would always detach the ref before that component's render is called. Now, we change the `ref` later, when applying the changes to the DOM.
  * It is not safe to re-render into a container that was modified by something other than React. This worked previously in some cases but was never supported. We now emit a warning in this case. Instead you should clean up your component trees using `ReactDOM.unmountComponentAtNode`. [See this example.](`https://github.com/facebook/react/issues/10294`#issuecomment-318820987)
  * `componentDidUpdate` lifecycle no longer receives `prevContext` param. ([@&#8203;bvaughn] in [#&#8203;8631](`https://github.com/facebook/react/pull/8631`))
  * Non-unique keys may now cause children to be duplicated and/or omitted. Using non-unique keys is not (and has never been) supported, but previously it was a hard error.
  * Shallow renderer no longer calls `componentDidUpdate()` because DOM refs are not available. This also makes it consistent with `componentDidMount()` (which does not get called in previous versions either).
  * Shallow renderer does not implement `unstable_batchedUpdates()` anymore.
  * `ReactDOM.unstable_batchedUpdates` now only takes one extra argument after the callback.
- The names and paths to the single-file browser builds have changed to emphasize the difference between development and production builds. For example:
  - `react/dist/react.js` → `react/umd/react.development.js`
  - `react/dist/react.min.js` → `react/umd/react.production.min.js`
  - `react-dom/dist/react-dom.js` → `react-dom/umd/react-dom.development.js`
  - `react-dom/dist/react-dom.min.js` → `react-dom/umd/react-dom.production.min.js`
* The server renderer has been completely rewritten, with some improvements:
  * Server rendering does not use markup validation anymore, and instead tries its best to attach to existing DOM, warning about inconsistencies. It also doesn't use comments for empty components and data-reactid attributes on each node anymore.
  * Hydrating a server rendered container now has an explicit API. Use `ReactDOM.hydrate` instead of `ReactDOM.render` if you're reviving server rendered HTML. Keep using `ReactDOM.render` if you're just doing client-side rendering.
* When "unknown" props are passed to DOM components, for valid values, React will now render them in the DOM. [See this post for more details.](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html) ([@&#8203;nhunzaker] in [#&#8203;10385](`https://github.com/facebook/react/pull/10385`), [10564](`https://github.com/facebook/react/pull/10564`), [#&#8203;10495](`https://github.com/facebook/react/pull/10495`) and others)
* Errors in the render and lifecycle methods now unmount the component tree by default. To prevent this, add [error boundaries](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html) to the appropriate places in the UI.
##### Removed Deprecations

- There is no `react-with-addons.js` build anymore. All compatible addons are published separately on npm, and have single-file browser versions if you need them.
- The deprecations introduced in 15.x have been removed from the core package. `React.createClass` is now available as create-react-class, `React.PropTypes` as prop-types, `React.DOM` as react-dom-factories, react-addons-test-utils as react-dom/test-utils, and shallow renderer as react-test-renderer/shallow. See [15.5.0](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html) and [15.6.0](https://reactjs.org/blog/2017/06/13/react-v15.6.0.html) blog posts for instructions on migrating code and automated codemods.

---

### [`v16.1.0`](https://github.com/facebook/react/blob/master/CHANGELOG.md#&#8203;1610-November-9-2017)

##### Discontinuing Bower Releases

Starting with 16.1.0, we will no longer be publishing new releases on Bower. You can continue using Bower for old releases, or point your Bower configs to the [React UMD builds hosted on unpkg](https://reactjs.org/docs/installation.html#using-a-cdn) that mirror npm releases and will continue to be updated.
##### All Packages

* Fix an accidental extra global variable in the UMD builds. ([@&#8203;gaearon] in [#&#8203;10935](`https://github.com/facebook/react/pull/10935`))
##### React

* Add support for portals in `React.Children` utilities. ([@&#8203;MatteoVH] in [#&#8203;11378](`https://github.com/facebook/react/pull/11378`))
* Warn when a class has a `render` method but doesn't extend a known base class. ([@&#8203;sw-yx] in [#&#8203;11168](`https://github.com/facebook/react/pull/11168`))
* Improve the warning when accidentally returning an object from constructor. ([@&#8203;deanbrophy] in [#&#8203;11395](`https://github.com/facebook/react/pull/11395`))
##### React DOM

* Allow `on` as a custom attribute for AMP. ([@&#8203;nuc] in [#&#8203;11153](`https://github.com/facebook/react/pull/11153`))
* Fix `onMouseEnter` and `onMouseLeave` firing on wrong elements. ([@&#8203;gaearon] in [#&#8203;11164](`https://github.com/facebook/react/pull/11164`))
* Fix `null` showing up in a warning instead of the component stack. ([@&#8203;gaearon] in [#&#8203;10915](`https://github.com/facebook/react/pull/10915`))
* Fix IE11 crash in development mode. ([@&#8203;leidegre] in [#&#8203;10921](`https://github.com/facebook/react/pull/10921`))
* Fix `tabIndex` not getting applied to SVG elements. ([@&#8203;gaearon] in [#&#8203;11034](`https://github.com/facebook/react/pull/11034`))
* Fix SVG children not getting cleaned up on `dangerouslySetInnerHTML` in IE. ([@&#8203;OriR] in [#&#8203;11108](`https://github.com/facebook/react/pull/11108`))
* Fix false positive text mismatch warning caused by newline normalization. ([@&#8203;gaearon] in [#&#8203;11119](`https://github.com/facebook/react/pull/11119`))
* Fix `form.reset()` to respect `defaultValue` on uncontrolled `<select>`. ([@&#8203;aweary] in [#&#8203;11057](`https://github.com/facebook/react/pull/11057`))
* Fix `<textarea>` placeholder not rendering on IE11. ([@&#8203;gaearon] in [#&#8203;11177](`https://github.com/facebook/react/pull/11177`))
* Fix a crash rendering into shadow root. ([@&#8203;gaearon] in [#&#8203;11037](`https://github.com/facebook/react/pull/11037`))
* Fix false positive warning about hydrating mixed case SVG tags. ([@&#8203;gaearon] in [#&#8203;11174](`https://github.com/facebook/react/pull/11174`))
* Suppress the new unknown tag warning for `<dialog>` element. ([@&#8203;gaearon] in [#&#8203;11035](`https://github.com/facebook/react/pull/11035`))
* Warn when defining a non-existent `componentDidReceiveProps` method. ([@&#8203;iamtommcc] in [#&#8203;11479](`https://github.com/facebook/react/pull/11479`))
* Warn about function child no more than once. ([@&#8203;andreysaleba] in [#&#8203;11120](`https://github.com/facebook/react/pull/11120`))
* Warn about nested updates no more than once. ([@&#8203;anushreesubramani] in [#&#8203;11113](`https://github.com/facebook/react/pull/11113`))
* Deduplicate other warnings about updates. ([@&#8203;anushreesubramani] in [#&#8203;11216](`https://github.com/facebook/react/pull/11216`))
* Include component stack into the warning about `contentEditable` and `children`. ([@&#8203;Ethan-Arrowood] in [#&#8203;11208](`https://github.com/facebook/react/pull/11208`))
* Improve the warning about booleans passed to event handlers. ([@&#8203;NicBonetto] in [#&#8203;11308](`https://github.com/facebook/react/pull/11308`))
* Improve the warning when a multiple `select` gets null `value`. ([@&#8203;Hendeca] in [#&#8203;11141](`https://github.com/facebook/react/pull/11141`))
* Move link in the warning message to avoid redirect. ([@&#8203;marciovicente] in [#&#8203;11400](`https://github.com/facebook/react/pull/11400`))
* Add a way to suppress the React DevTools installation prompt. ([@&#8203;gaearon] in [#&#8203;11448](`https://github.com/facebook/react/pull/11448`))
* Remove unused code. ([@&#8203;gaearon] in [#&#8203;10802](`https://github.com/facebook/react/pull/10802`), [#&#8203;10803](`https://github.com/facebook/react/pull/10803`))
##### React DOM Server

* Add a new `suppressHydrationWarning` attribute for intentional client/server text mismatches. ([@&#8203;sebmarkbage] in [#&#8203;11126](`https://github.com/facebook/react/pull/11126`))
* Fix markup generation when components return strings. ([@&#8203;gaearon] in [#&#8203;11109](`https://github.com/facebook/react/pull/11109`))
* Fix obscure error message when passing an invalid style value. ([@&#8203;iamdustan] in [#&#8203;11173](`https://github.com/facebook/react/pull/11173`))
* Include the `autoFocus` attribute into SSR markup. ([@&#8203;gaearon] in [#&#8203;11192](`https://github.com/facebook/react/pull/11192`))
* Include the component stack into more warnings. ([@&#8203;gaearon] in [#&#8203;11284](`https://github.com/facebook/react/pull/11284`))
##### React Test Renderer and Test Utils

* Fix multiple `setState()` calls in `componentWillMount()` in shallow renderer. ([@&#8203;Hypnosphi] in [#&#8203;11167](`https://github.com/facebook/react/pull/11167`))
* Fix shallow renderer to ignore `shouldComponentUpdate()` after `forceUpdate()`. ([@&#8203;d4rky-pl] in [#&#8203;11239](`https://github.com/facebook/react/pull/11239`) and [#&#8203;11439](`https://github.com/facebook/react/pull/11439`))
* Handle `forceUpdate()` and `React.PureComponent` correctly. ([@&#8203;koba04] in [#&#8203;11440](`https://github.com/facebook/react/pull/11440`))
* Add back support for running in production mode. ([@&#8203;gaearon] in [#&#8203;11112](`https://github.com/facebook/react/pull/11112`))
* Add a missing `package.json` dependency. ([@&#8203;gaearon] in [#&#8203;11340](`https://github.com/facebook/react/pull/11340`))
##### React ART

* Add a missing `package.json` dependency. ([@&#8203;gaearon] in [#&#8203;11341](`https://github.com/facebook/react/pull/11341`))
* Expose `react-art/Circle`, `react-art/Rectangle`, and `react-art/Wedge`. ([@&#8203;gaearon] in [#&#8203;11343](`https://github.com/facebook/react/pull/11343`))
##### React Reconciler (Experimental)

* First release of the [new experimental package](https://github.com/facebook/react/blob/master/packages/react-reconciler/README.md) for creating custom renderers. ([@&#8203;iamdustan] in [#&#8203;10758](`https://github.com/facebook/react/pull/10758`))
* Add support for React DevTools. ([@&#8203;gaearon] in [#&#8203;11463](`https://github.com/facebook/react/pull/11463`))
##### React Call Return (Experimental)

* First release of the [new experimental package](https://github.com/facebook/react/tree/master/packages/react-call-return) for parent-child communication. ([@&#8203;gaearon] in [#&#8203;11364](`https://github.com/facebook/react/pull/11364`))

---

### [`v16.1.1`](https://github.com/facebook/react/blob/master/CHANGELOG.md#&#8203;1611-November-13-2017)

##### React

* Improve the warning about undefined component type. ([@&#8203;selbekk] in [#&#8203;11505](`https://github.com/facebook/react/pull/11505`))
##### React DOM

* Support string values for the `capture` attribute. ([@&#8203;maxschmeling] in [#&#8203;11424](`https://github.com/facebook/react/pull/11424`))
##### React DOM Server

* Don't freeze the `ReactDOMServer` public API. ([@&#8203;travi] in [#&#8203;11531](`https://github.com/facebook/react/pull/11531`))
* Don't emit `autoFocus={false}` attribute on the server. ([@&#8203;gaearon] in [#&#8203;11543](`https://github.com/facebook/react/pull/11543`))
##### React Reconciler

* Change the hydration API for better Flow typing. ([@&#8203;sebmarkbage] in [#&#8203;11493](`https://github.com/facebook/react/pull/11493`))

---

### [`v16.2.0`](https://github.com/facebook/react/blob/master/CHANGELOG.md#&#8203;1620-November-28-2017)

##### React

* Add `Fragment` as named export to React. ([@&#8203;clemmy] in [#&#8203;10783](`https://github.com/facebook/react/pull/10783`))
* Support experimental Call/Return types in `React.Children` utilities. ([@&#8203;MatteoVH] in [#&#8203;11422](`https://github.com/facebook/react/pull/11422`))
##### React DOM

* Fix radio buttons not getting checked when using multiple lists of radios. ([@&#8203;landvibe] in [#&#8203;11227](`https://github.com/facebook/react/pull/11227`))
* Fix radio buttons not receiving the `onChange` event in some cases. ([@&#8203;jquense] in [#&#8203;11028](`https://github.com/facebook/react/pull/11028`))
##### React Test Renderer

* Fix `setState()` callback firing too early when called from `componentWillMount`. ([@&#8203;accordeiro] in [#&#8203;11507](`https://github.com/facebook/react/pull/11507`))
##### React Reconciler

* Expose `react-reconciler/reflection` with utilities useful to custom renderers. ([@&#8203;rivenhk] in [#&#8203;11683](`https://github.com/facebook/react/pull/11683`))
##### Internal Changes

* Many tests were rewritten against the public API. Big thanks to [everyone who contributed](`https://github.com/facebook/react/issues/11299`)!

---

### [`v16.3.0`](https://github.com/facebook/react/blob/master/CHANGELOG.md#&#8203;1630-March-29-2018)

##### React

* Add a new officially supported context API. ([@&#8203;acdlite] in [#&#8203;11818](`https://github.com/facebook/react/pull/11818`))
* Add a new `React.createRef()` API as an ergonomic alternative to callback refs. ([@&#8203;trueadm] in [#&#8203;12162](`https://github.com/facebook/react/pull/12162`))
* Add a new `React.forwardRef()` API to let components forward their refs to a child. ([@&#8203;bvaughn] in [#&#8203;12346](`https://github.com/facebook/react/pull/12346`))
* Fix a false positive warning in IE11 when using `React.Fragment`. ([@&#8203;XaveScor] in [#&#8203;11823](`https://github.com/facebook/react/pull/11823`))
* Replace `React.unstable_AsyncComponent` with `React.unstable_AsyncMode`. ([@&#8203;acdlite] in [#&#8203;12117](`https://github.com/facebook/react/pull/12117`))
* Improve the error message when calling `setState()` on an unmounted component. ([@&#8203;sophiebits] in [#&#8203;12347](`https://github.com/facebook/react/pull/12347`))
##### React DOM

* Add a new `getDerivedStateFromProps()` lifecycle and `UNSAFE_` aliases for the legacy lifecycles. ([@&#8203;bvaughn] in [#&#8203;12028](`https://github.com/facebook/react/pull/12028`))
* Add a new `getSnapshotBeforeUpdate()` lifecycle. ([@&#8203;bvaughn] in [#&#8203;12404](`https://github.com/facebook/react/pull/12404`))
* Add a new `<React.StrictMode>` wrapper to help prepare apps for async rendering. ([@&#8203;bvaughn] in [#&#8203;12083](`https://github.com/facebook/react/pull/12083`))
* Add support for `onLoad` and `onError` events on the `<link>` tag. ([@&#8203;roderickhsiao] in [#&#8203;11825](`https://github.com/facebook/react/pull/11825`))
* Add support for `noModule` boolean attribute on the `<script>` tag. ([@&#8203;aweary] in [#&#8203;11900](`https://github.com/facebook/react/pull/11900`))
* Fix minor DOM input bugs in IE and Safari. ([@&#8203;nhunzaker] in [#&#8203;11534](`https://github.com/facebook/react/pull/11534`))
* Correctly detect Ctrl + Enter in `onKeyPress` in more browsers. ([@&#8203;nstraub] in [#&#8203;10514](`https://github.com/facebook/react/pull/10514`))
* Fix containing elements getting focused on SSR markup mismatch. ([@&#8203;koba04] in [#&#8203;11737](`https://github.com/facebook/react/pull/11737`))
* Fix `value` and `defaultValue` to ignore Symbol values. ([@&#8203;nhunzaker] in [#&#8203;11741](`https://github.com/facebook/react/pull/11741`))
* Fix refs to class components not getting cleaned up when the attribute is removed. ([@&#8203;bvaughn] in [#&#8203;12178](`https://github.com/facebook/react/pull/12178`))
* Fix an IE/Edge issue when rendering inputs into a different window. ([@&#8203;M-ZubairAhmed] in [#&#8203;11870](`https://github.com/facebook/react/pull/11870`))
* Throw with a meaningful message if the component runs after jsdom has been destroyed. ([@&#8203;gaearon] in [#&#8203;11677](`https://github.com/facebook/react/pull/11677`))
* Don't crash if there is a global variable called `opera` with a `null` value. [@&#8203;alisherdavronov] in [#&#8203;11854](`https://github.com/facebook/react/pull/11854`))
* Don't check for old versions of Opera. ([@&#8203;skiritsis] in [#&#8203;11921](`https://github.com/facebook/react/pull/11921`))
* Deduplicate warning messages about `<option selected>`. ([@&#8203;watadarkstar] in [#&#8203;11821](`https://github.com/facebook/react/pull/11821`))
* Deduplicate warning messages about invalid callback. ([@&#8203;yenshih] in [#&#8203;11833](`https://github.com/facebook/react/pull/11833`))
* Deprecate `ReactDOM.unstable_createPortal()` in favor of `ReactDOM.createPortal()`. ([@&#8203;prometheansacrifice] in [#&#8203;11747](`https://github.com/facebook/react/pull/11747`))
* Don't emit User Timing entries for context types. ([@&#8203;abhaynikam] in [#&#8203;12250](`https://github.com/facebook/react/pull/12250`))
* Improve the error message when context consumer child isn't a function. ([@&#8203;raunofreiberg] in [#&#8203;12267](`https://github.com/facebook/react/pull/12267`)) 
* Improve the error message when adding a ref to a functional component. ([@&#8203;skiritsis] in [#&#8203;11782](`https://github.com/facebook/react/pull/11782`))
##### React DOM Server

* Prevent an infinite loop when attempting to render portals with SSR. ([@&#8203;gaearon] in [#&#8203;11709](`https://github.com/facebook/react/pull/11709`))
* Warn if a class doesn't extend `React.Component`. ([@&#8203;wyze] in [#&#8203;11993](`https://github.com/facebook/react/pull/11993`))
* Fix an issue with `this.state` of different components getting mixed up. ([@&#8203;sophiebits] in [#&#8203;12323](`https://github.com/facebook/react/pull/12323`))
* Provide a better message when component type is undefined. ([@&#8203;HeroProtagonist] in [#&#8203;11966](`https://github.com/facebook/react/pull/11966`))

---

### [`v16.3.1`](https://github.com/facebook/react/blob/master/CHANGELOG.md#&#8203;1631-April-3-2018)

##### React

* Fix a false positive warning in IE11 when using `Fragment`. ([@&#8203;heikkilamarko] in [#&#8203;12504](`https://github.com/facebook/react/pull/12504`))
* Prefix a private API. ([@&#8203;Andarist] in [#&#8203;12501](`https://github.com/facebook/react/pull/12501`))
* Improve the warning when calling `setState()` in constructor. ([@&#8203;gaearon] in [#&#8203;12532](`https://github.com/facebook/react/pull/12532`))
##### React DOM

* Fix `getDerivedStateFromProps()` not getting applied in some cases. ([@&#8203;acdlite] in [#&#8203;12528](`https://github.com/facebook/react/pull/12528`))
* Fix a performance regression in development mode. ([@&#8203;gaearon] in [#&#8203;12510](`https://github.com/facebook/react/pull/12510`))
* Fix error handling bugs in development mode. ([@&#8203;gaearon] and [@&#8203;acdlite] in [#&#8203;12508](`https://github.com/facebook/react/pull/12508`))
* Improve user timing API messages for profiling. ([@&#8203;flarnie] in [#&#8203;12384](`https://github.com/facebook/react/pull/12384`))
##### Create Subscription

* Set the package version to be in sync with React releases. ([@&#8203;bvaughn] in [#&#8203;12526](`https://github.com/facebook/react/pull/12526`))
* Add a peer dependency on React 16.3+. ([@&#8203;NMinhNguyen] in [#&#8203;12496](`https://github.com/facebook/react/pull/12496`))

---

</details>


<details>
<summary>Commits</summary>

#### v16.3.0
-   [`c2c3c0c`](https://github.com/facebook/react/commit/c2c3c0cc36878cd6f020a480b83ff1c03b62fd28) Fix build script to handle react-is (no peer deps) (#&#8203;12471)
-   [`488ad5a`](https://github.com/facebook/react/commit/488ad5a6b94ac4b71ff587ecde05e48a218aba62) Fix typo in create-subscription readme
-   [`c1b21a7`](https://github.com/facebook/react/commit/c1b21a746c7d08554eed8bf55030a4049380c32c) Added DEV warning if getSnapshotBeforeUpdate is defined as a static method (#&#8203;12475)
-   [`268a3f6`](https://github.com/facebook/react/commit/268a3f60dfe67c4f6439fc37b569a2d81c81a53a) Add unstable APIs for async rendering to test renderer (#&#8203;12478)
-   [`c44665e`](https://github.com/facebook/react/commit/c44665e83278becfe7a3afdf788789536d63387b) Fix bug when fatal error is thrown as a result of `batch.commit` (#&#8203;12480)
-   [`7a833da`](https://github.com/facebook/react/commit/7a833dad95b3059ebfdfba44d3fa68e1301d8e6a) setState() in componentDidMount() should flush synchronously even with createBatch() (#&#8203;12466)
-   [`5855e9f`](https://github.com/facebook/react/commit/5855e9f2158b31d945f3fcc5bc582389dbecc88e) Improve warning message for setState-on-unmounted (#&#8203;12347)
-   [`15e3dff`](https://github.com/facebook/react/commit/15e3dffb4c9ca9b9466f4ef1a6b8b2293d41e9d6) Don&#x27;t bail out on referential equality of Consumer&#x27;s props.children function (#&#8203;12470)
-   [`125dd16`](https://github.com/facebook/react/commit/125dd16ba0b3fa74767b1cf417a3116a4a2b251a) Update user timing to record the timeout deadline with &#x27;waiting&#x27; events (#&#8203;12479)
-   [`96fe3b1`](https://github.com/facebook/react/commit/96fe3b1be2fe74e83c9a25d7511f23dbef15ac99) Add React.isValidElementType() (#&#8203;12483)
-   [`53fdc19`](https://github.com/facebook/react/commit/53fdc19df092bbc4bd736aea4ef8e0f12d692ee6) Updated react-is README to show new isValidElementType()
-   [`8650d2a`](https://github.com/facebook/react/commit/8650d2a1357985958c2738da55ea349406482721) Disable createRoot for open source builds (#&#8203;12486)
-   [`6294b67`](https://github.com/facebook/react/commit/6294b67a406d21cc6b65162e47497c1e8afe398f) unstable_createRoot (#&#8203;12487)
-   [`b2379d4`](https://github.com/facebook/react/commit/b2379d4cbe82653da931ccb128916707bc53d28a) Updating package versions for release 16.3.0
-   [`9778873`](https://github.com/facebook/react/commit/9778873143072635a795fec2ad0e1ac0bb7d8b91) Updating dependencies for react-noop-renderer
-   [`8e3d94f`](https://github.com/facebook/react/commit/8e3d94ffa1d2e19a5bf4b9f8030973b65b0fc854) Update bundle sizes for 16.3.0 release
#### v16.3.1
-   [`2c3f5fb`](https://github.com/facebook/react/commit/2c3f5fb97b6ea077f3e9aae6c6587bfe8328036d) Add React 16.3.0 changelog (#&#8203;12488)
-   [`4304475`](https://github.com/facebook/react/commit/43044757e55eca13ae788056b59f94788fc15050) Fix links
-   [`18ba36d`](https://github.com/facebook/react/commit/18ba36d89165ec15655f2606b0a6ba2e709ce641) Move context API in Changelog to &quot;React&quot; section
-   [`59b3905`](https://github.com/facebook/react/commit/59b39056d91787f6a3e4e0dfc0825c8687bd0af9) Fix method name in changelog
-   [`fa8e678`](https://github.com/facebook/react/commit/fa8e67893fca1b3902637129972032bca248a584) Change create-subscription&#x27;s peerDep on react to ^16.3.0 (#&#8203;12496)
-   [`0c80977`](https://github.com/facebook/react/commit/0c80977061ba576cee9ae0891245be233929d2ed) Validate React.Fragment props without Map. (#&#8203;12504)
-   [`59dac9d`](https://github.com/facebook/react/commit/59dac9d7a6a2f0b66003cf717d71b5587265423f) Fix DEV performance regression by avoiding Object.assign on Fibers (#&#8203;12510)
-   [`6b99c6f`](https://github.com/facebook/react/commit/6b99c6f9d376bacbb769264d743c405b495b03ad) Add missing changelog item
-   [`7a27ebd`](https://github.com/facebook/react/commit/7a27ebd52a3025a946c67eaf84d2646fd307cb44) Update user timing to record when we are about to commit (#&#8203;12384)
-   [`4ccf58a`](https://github.com/facebook/react/commit/4ccf58a94dce323718540b8185a32070ded6094b) Fix context stack misalignment caused by error replay (#&#8203;12508)
-   [`6f2ea73`](https://github.com/facebook/react/commit/6f2ea73978168372f33a6dfad6c049afddc4aef3) Extract throw to separate function so performUnitOfWork does not deopt (#&#8203;12521)
-   [`ba245f6`](https://github.com/facebook/react/commit/ba245f6f9b0bf31c2ebff5c087c21bcae111e6c3) Prefix _context property on returned ReactContext from createContext - it&#x27;s private (#&#8203;12501)
-   [`eb6e752`](https://github.com/facebook/react/commit/eb6e752cabafed0b72e1d0a38819ff156557d537) Bumped create-subscription package version (#&#8203;12526)
-   [`da4e855`](https://github.com/facebook/react/commit/da4e85567b411a180c2cfa1ef6573cf3cc9257f1) Remove @&#8203;providesModule in www bundles (#&#8203;12529)
-   [`0f2f90b`](https://github.com/facebook/react/commit/0f2f90bd9a9daf241d691bf4af3ea2e3a263c0e3) getDerivedStateFrom{Props,Catch} should update updateQueue.baseState (#&#8203;12528)
-   [`36c2939`](https://github.com/facebook/react/commit/36c29393720157a3966ce1d50449a33a35bdf14c) Improve not-yet-mounted setState warning (#&#8203;12531)
-   [`a2cc3c3`](https://github.com/facebook/react/commit/a2cc3c38e214c16ff6805312d4353c1faab9ff95) Follow up: make new warning less wordy (#&#8203;12532)
-   [`2279843`](https://github.com/facebook/react/commit/2279843ef966ea2e0460986efa1f91513cd50623) Updating yarn.lock file for 16.3.1 release
-   [`787b343`](https://github.com/facebook/react/commit/787b343f674c72837209bdffd55c59682910d807) Updating package versions for release 16.3.1
-   [`dc05957`](https://github.com/facebook/react/commit/dc059579c3e56ca338a999b86d146d2341ee6f64) Update bundle sizes for 16.3.1 release
-   [`b15b165`](https://github.com/facebook/react/commit/b15b165e0798dca03492e354ebd5bcf87b711184) Changelog for 16.3.1

</details>