### PR TITLE
chore(deps): update dependency style-loader to ^0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18173,9 +18173,9 @@
       "dev": true
     },
     "style-loader": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
-      "integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.21.0.tgz",
+      "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "scss-loader": "0.0.1",
     "skin-deep": "^1.2.0",
     "standard": "^11.0.1",
-    "style-loader": "^0.20.3",
+    "style-loader": "^0.21.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
     "surge": "^0.20.1",


### PR DESCRIPTION
This Pull Request updates dependency [style-loader](https://github.com/webpack-contrib/style-loader) from `^0.20.3` to `^0.21.0`



<details>
<summary>Release Notes</summary>

### [`v0.21.0`](https://github.com/webpack-contrib/style-loader/blob/master/CHANGELOG.md#&#8203;0210httpsgithubcomwebpack-contribstyle-loadercomparev0203v0210-2018-04-18)

##### Features

* enable tag type configuration ([#&#8203;316](`https://github.com/webpack-contrib/style-loader/issues/316`)) ([892cba5](https://github.com/webpack-contrib/style-loader/commit/892cba5))
#### [0.20.3](https://github.com/webpack-contrib/style-loader/compare/v0.20.2...v0.20.3) (2018-03-09)
##### Bug Fixes

* **package:** update `schema-utils` v0.4.3...0.4.5 (`dependencies`) ([#&#8203;308](`https://github.com/webpack-contrib/style-loader/issues/308`)) ([9455888](https://github.com/webpack-contrib/style-loader/commit/9455888))
#### [0.20.2](https://github.com/webpack-contrib/style-loader/compare/v0.20.1...v0.20.2) (2018-02-15)
##### Bug Fixes

* **urls:** skip empty `url()` handling ([#&#8203;304](`https://github.com/webpack-contrib/style-loader/issues/304`)) ([64f12dc](https://github.com/webpack-contrib/style-loader/commit/64f12dc))
#### [0.20.1](https://github.com/webpack-contrib/style-loader/compare/v0.20.0...v0.20.1) (2018-01-26)
##### Bug Fixes

* **index:** source code indentation ([#&#8203;299](`https://github.com/webpack-contrib/style-loader/issues/299`)) ([b4642e7](https://github.com/webpack-contrib/style-loader/commit/b4642e7))

---

</details>


<details>
<summary>Commits</summary>

#### v0.21.0
-   [`78ca637`](https://github.com/webpack-contrib/style-loader/commit/78ca637690c29db2052e7dfb81b3fae69a8b12ba) ci(circle): Swap out travis for CircleCI 2.0 config
-   [`91902a0`](https://github.com/webpack-contrib/style-loader/commit/91902a08833ff27be4ac44de0e6b3a33a04273af) chore(package): Adds nsp for security check
-   [`2c1d451`](https://github.com/webpack-contrib/style-loader/commit/2c1d45137fcd6366c8fa687fa71867dd5ae2b8af) ci(circle): Short circuit canary suite
-   [`342b3c6`](https://github.com/webpack-contrib/style-loader/commit/342b3c6e3cf3d5d32cda8b51814a054640b53b15) ci(circle): Use single thread jest script
-   [`2c3e6b5`](https://github.com/webpack-contrib/style-loader/commit/2c3e6b57ac8abbd895047ae8b70620d27e95fbd4) ci(circle): Removes setup docker command
-   [`892cba5`](https://github.com/webpack-contrib/style-loader/commit/892cba5ad5d654e1db027b96f82caf683cbd29bb) feat: enable tag type configuration (#&#8203;316)
-   [`e4fa68a`](https://github.com/webpack-contrib/style-loader/commit/e4fa68a19d2390e265e27ec60ae928bf80a41228) chore(release): 0.21.0

</details>