### PR TITLE
chore(deps): update dependency babel-core to v6.26.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -986,9 +986,10 @@
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
     "babel-cli": "^6.26.0",
-    "babel-core": "6.26.0",
+    "babel-core": "6.26.3",
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.4",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
This Pull Request updates dependency [babel-core](https://babeljs.io/) from `v6.26.0` to `v6.26.3`