### PR TITLE
chore(deps): update dependency codacy-coverage to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3358,19 +3358,47 @@
       }
     },
     "codacy-coverage": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/codacy-coverage/-/codacy-coverage-2.1.1.tgz",
-      "integrity": "sha512-MGMkPS5d9AqQEXTZ4grn/syl/7VvOehgWTeU2B41E22q767QolclfdfadKAndL287cIPEOEdwh9JBqCwQJLtFw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/codacy-coverage/-/codacy-coverage-3.0.0.tgz",
+      "integrity": "sha512-hQJIMhBM5JYeIpu9gKHRmIK5uj9zWDtWBDGtW7PnWRYHMr1Wp93B+l5s82d6XymFJDCZENSp0uWY9zfR1meBwQ==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "commander": "2.14.1",
-        "joi": "12.0.0",
+        "joi": "13.2.0",
         "lcov-parse": "1.0.0",
         "lodash": "4.17.5",
         "log-driver": "1.2.7",
         "request": "2.83.0",
         "request-promise": "4.2.2"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+          "dev": true
+        },
+        "joi": {
+          "version": "13.2.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.2.0.tgz",
+          "integrity": "sha512-VUzQwyCrmT2lIpxBCYq26dcK9veCQzDh84gQnCtaxCa8ePohX8JZVVsIb+E66kCUUcIvzeIpifa6eZuzqTZ3NA==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.0.3",
+            "isemail": "3.1.2",
+            "topo": "3.0.0"
+          }
+        },
+        "topo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+          "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.0.3"
+          }
+        }
       }
     },
     "code-point-at": {
@@ -9749,17 +9777,6 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
       "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
       "dev": true
-    },
-    "joi": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
-      "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1",
-        "isemail": "3.1.2",
-        "topo": "2.0.2"
-      }
     },
     "jquery": {
       "version": "3.3.1",
@@ -18759,15 +18776,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
       "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
-    },
-    "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
-      }
     },
     "tough-cookie": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.26.0",
     "bithound": "^1.7.0",
-    "codacy-coverage": "^2.1.1",
+    "codacy-coverage": "^3.0.0",
     "codecov": "^3.0.0",
     "css-loader": "^0.28.11",
     "enzyme": "^3.3.0",


### PR DESCRIPTION
This Pull Request updates dependency [codacy-coverage](https://github.com/codacy/node-codacy-coverage) from `^2.1.1` to `^3.0.0`



<details>
<summary>Release Notes</summary>

### [`v3.0.0`](https://github.com/codacy/node-codacy-coverage/releases/v3.0.0)

* Update Joi dependency
* Remove support for Node 4 and 5

---

</details>


<details>
<summary>Commits</summary>

#### v3.0.0
-   [`93003cf`](https://github.com/codacy/node-codacy-coverage/commit/93003cf27cb01b03ee6db48907e182fe720f0631) Release version 2.1.1
-   [`8bb9c3b`](https://github.com/codacy/node-codacy-coverage/commit/8bb9c3bb84af325e3d42b0a2ab40fb4bed895e23) Update joi
-   [`4aa76d3`](https://github.com/codacy/node-codacy-coverage/commit/4aa76d3bbb4ba10deccc1f192a4ccf1d0fc51cac) Remove support for node 4 and 5
-   [`e5c6227`](https://github.com/codacy/node-codacy-coverage/commit/e5c6227a8e49ea15f60046c059e63a66c7ab26cf) Merge pull request #&#8203;58 from codacy/update-joi

</details>