### PR TITLE
chore(deps): update dependency eslint-plugin-import to v2.11.0 (master)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5358,12 +5358,11 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.10.0.tgz",
-      "integrity": "sha1-+gkIPVp1KI35xsfQn+EiVZhWVec=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz",
+      "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
@@ -5372,7 +5371,8 @@
         "has": "1.0.1",
         "lodash": "4.17.5",
         "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.7.1"
       },
       "dependencies": {
         "doctrine": {
@@ -5444,6 +5444,15 @@
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "enzyme-adapter-react-15": "^1.0.5",
     "eslint": "^4.19.1",
     "eslint-plugin-filenames": "^1.2.0",
-    "eslint-plugin-import": "2.10.0",
+    "eslint-plugin-import": "2.11.0",
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-standard": "^3.0.1",


### PR DESCRIPTION
This Pull Request updates dependency [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) from `v2.10.0` to `v2.11.0`



<details>
<summary>Release Notes</summary>

### [`v2.11.0`](https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md#&#8203;2110---2018-04-09)
[Compare Source](https://github.com/benmosher/eslint-plugin-import/compare/v2.10.0...v2.11.0)
##### Added
- Fixer for [`first`] ([#&#8203;1046], thanks [@&#8203;fengkfengk])
- `allow-require` option for [`no-commonjs`] rule ([#&#8203;880], thanks [@&#8203;futpib])
##### Fixed
- memory/CPU regression where ASTs were held in memory ([#&#8203;1058], thanks [@&#8203;klimashkin]/[@&#8203;lukeapage])
#### [2.10.0] - 2018-03-29
##### Added
- Autofixer for [`order`] rule ([#&#8203;908], thanks [@&#8203;tihonove])
- Add [`no-cycle`] rule: reports import cycles.
#### [2.9.0] - 2018-02-21
##### Added
- Add [`group-exports`] rule: style-guide rule to report use of multiple named exports ([#&#8203;721], thanks [@&#8203;robertrossmann])
- Add [`no-self-import`] rule: forbids a module from importing itself. ([#&#8203;727], [#&#8203;449], [#&#8203;447], thanks [@&#8203;giodamelio]).
- Add [`no-default-export`] rule ([#&#8203;889], thanks [@&#8203;isiahmeadows])
- Add [`no-useless-path-segments`] rule ([#&#8203;912], thanks [@&#8203;graingert] and [@&#8203;danny-andrews])
- ... and more! check the commits for v[2.9.0]
#### [2.8.0] - 2017-10-18
##### Added
- [`exports-last`] rule ([#&#8203;620] + [#&#8203;632], thanks [@&#8203;k15a])
##### Changed
- Case-sensitivity checking ignores working directory and ancestors. ([#&#8203;720] + [#&#8203;858], thanks [@&#8203;laysent])
##### Fixed
- support scoped modules containing hyphens ([#&#8203;744], thanks [@&#8203;rosswarren])
- core-modules now resolves files inside declared modules ([#&#8203;886] / [#&#8203;891], thanks [@&#8203;mplewis])
- TypeError for missing AST fields from TypeScript ([#&#8203;842] / [#&#8203;944], thanks [@&#8203;alexgorbatchev])
#### [2.7.0] - 2017-07-06
##### Changed
- [`no-absolute-path`] picks up speed boost, optional AMD support ([#&#8203;843], thanks [@&#8203;jseminck])
#### [2.6.1] - 2017-06-29
##### Fixed
- update bundled node resolver dependency to latest version
#### [2.6.0] - 2017-06-23
##### Changed
- update tests / peerDeps for ESLint 4.0 compatibility ([#&#8203;871], thanks [@&#8203;mastilver])
- [`memo-parser`] updated to require `filePath` on parser options as it melts
  down if it's not there, now that this plugin always provides it. (see [#&#8203;863])
#### [2.5.0] - 2017-06-22

Re-releasing v[2.4.0] after discovering that the memory leak is isolated to the [`memo-parser`],
which is more or less experimental anyway.
##### Added
- Autofixer for newline-after-import. ([#&#8203;686] + [#&#8203;696], thanks [@&#8203;eelyafi])
#### [2.4.0] - 2017-06-02 [YANKED]

Yanked due to critical issue in eslint-module-utils with cache key resulting from [#&#8203;839].
##### Added
- Add `filePath` into `parserOptions` passed to `parser` ([#&#8203;839], thanks [@&#8203;sompylasar])
- Add `allow` option to [`no-unassigned-import`] to allow for files that match the globs ([#&#8203;671], [#&#8203;737], thanks [@&#8203;kevin940726]).
#### [2.3.0] - 2017-05-18
##### Added
- [`no-anonymous-default-export`] rule: report anonymous default exports ([#&#8203;712], thanks [@&#8203;duncanbeevers]).
- Add new value to [`order`]'s `newlines-between` option to allow newlines inside import groups ([#&#8203;627], [#&#8203;628], thanks [@&#8203;giodamelio])
- Add `count` option to the [`newline-after-import`] rule to allow configuration of number of newlines expected ([#&#8203;742], thanks [@&#8203;ntdb])
##### Changed
- [`no-extraneous-dependencies`]: use `read-pkg-up` to simplify finding + loading `package.json` ([#&#8203;680], thanks [@&#8203;wtgtybhertgeghgtwtg])
- Add support to specify the package.json [`no-extraneous-dependencies`] ([#&#8203;685], thanks [@&#8203;ramasilveyra])
##### Fixed
- attempt to fix crash in [`no-mutable-exports`]. ([#&#8203;660])
- "default is a reserved keyword" in no-maned-default tests by locking down babylon to 6.15.0 (#&#8203;756, thanks @&#8203;gmathieu)
- support scoped modules containing non word characters
#### [2.2.0] - 2016-11-07
##### Fixed
- Corrected a few gaffs in the auto-ignore logic to fix major performance issues
  with projects that did not explicitly ignore `node_modules`. ([#&#8203;654])
- [`import/ignore` setting] was only being respected if the ignored module didn't start with
  an `import` or `export` JS statement
- [`prefer-default-export`]: fixed crash on export extensions ([#&#8203;653])
#### [2.1.0] - 2016-11-02
##### Added
- Add [`no-named-default`] rule: style-guide rule to report use of unnecessarily named default imports ([#&#8203;596], thanks [@&#8203;ntdb])
- [`no-extraneous-dependencies`]: check globs against CWD + absolute path ([#&#8203;602] + [#&#8203;630], thanks [@&#8203;ljharb])
##### Fixed
- [`prefer-default-export`] handles flow `export type` ([#&#8203;484] + [#&#8203;639], thanks [@&#8203;jakubsta])
- [`prefer-default-export`] handles re-exported default exports ([#&#8203;609])
- Fix crash when using [`newline-after-import`] with decorators ([#&#8203;592])
- Properly report [`newline-after-import`] when next line is a decorator
- Fixed documentation for the default values for the [`order`] rule ([#&#8203;601])
#### [2.0.1] - 2016-10-06
##### Fixed
- Fixed code that relied on removed dependencies. ([#&#8203;604])
#### [2.0.0]! - 2016-09-30
##### Added
- [`unambiguous`] rule: report modules that are not unambiguously ES modules.
- `recommended` shared config. Roughly `errors` and `warnings` mixed together,
  with some `parserOptions` in the mix. ([#&#8203;402])
- `react` shared config: added `jsx: true` to `parserOptions.ecmaFeatures`.
- Added [`no-webpack-loader-syntax`] rule: forbid custom Webpack loader syntax in imports. ([#&#8203;586], thanks [@&#8203;fson]!)
- Add option `newlines-between: "ignore"` to [`order`] ([#&#8203;519])
- Added [`no-unassigned-import`] rule ([#&#8203;529])
##### Breaking
- [`import/extensions` setting] defaults to `['.js']`. ([#&#8203;306])
- [`import/ignore` setting] defaults to nothing, and ambiguous modules are ignored natively. This means importing from CommonJS modules will no longer be reported by [`default`], [`named`], or [`namespace`], regardless of `import/ignore`. ([#&#8203;270])
- [`newline-after-import`]: Removed need for an empty line after an inline `require` call ([#&#8203;570])
- [`order`]: Default value for `newlines-between` option is now `ignore` ([#&#8203;519])
##### Changed
- `imports-first` is renamed to [`first`]. `imports-first` alias will continue to
  exist, but may be removed in a future major release.
- Case-sensitivity: now specifically (and optionally) reported by [`no-unresolved`].
  Other rules will ignore case-mismatches on paths on case-insensitive filesystems. ([#&#8203;311])
##### Fixed
- [`no-internal-modules`]: support `@`-scoped packages ([#&#8203;577]+[#&#8203;578], thanks [@&#8203;spalger])
#### [1.16.0] - 2016-09-22
##### Added
- Added [`no-dynamic-require`] rule: forbid `require()` calls with expressions. ([#&#8203;567], [#&#8203;568])
- Added [`no-internal-modules`] rule: restrict deep package imports to specific folders. ([#&#8203;485], thanks [@&#8203;spalger]!)
- [`extensions`]: allow override of a chosen default with options object ([#&#8203;555], thanks [@&#8203;ljharb]!)
##### Fixed
- [`no-named-as-default`] no longer false-positives on `export default from '...'` ([#&#8203;566], thanks [@&#8203;preco21])
- [`default`]: allow re-export of values from ignored files as default ([#&#8203;545], thanks [@&#8203;skyrpex])
#### [1.15.0] - 2016-09-12
##### Added
- Added an `allow` option to [`no-nodejs-modules`] to allow exceptions ([#&#8203;452], [#&#8203;509]).
- Added [`no-absolute-path`] rule ([#&#8203;530], [#&#8203;538])
- [`max-dependencies`] for specifying the maximum number of dependencies (both `import` and `require`) a module can have. (see [#&#8203;489], thanks [@&#8203;tizmagik])
- Added glob option to config for [`no-extraneous-dependencies`], after much bikeshedding. Thanks, [@&#8203;knpwrs]! ([#&#8203;527])
##### Fixed
- [`no-named-as-default-member`] Allow default import to have a property named "default" ([#&#8203;507], [#&#8203;508], thanks [@&#8203;jquense] for both!)
#### [1.14.0] - 2016-08-22
##### Added
- [`import/parsers` setting]: parse some dependencies (i.e. TypeScript!) with a different parser than the ESLint-configured parser. ([#&#8203;503])
##### Fixed
- [`namespace`] exception for get property from `namespace` import, which are re-export from commonjs module ([#&#8203;499] fixes [#&#8203;416], thanks [@&#8203;wKich])
#### [1.13.0] - 2016-08-11
##### Added
- `allowComputed` option for [`namespace`] rule. If set to `true`, won't report
  computed member references to namespaces. (see [#&#8203;456])
##### Changed
- Modified [`no-nodejs-modules`] error message to include the module's name ([#&#8203;453], [#&#8203;461])
##### Fixed
- [`import/extensions` setting] is respected in spite of the appearance of imports
  in an imported file. (fixes [#&#8203;478], thanks [@&#8203;rhys-vdw])
#### [1.12.0] - 2016-07-26
##### Added
- [`import/external-module-folders` setting]: a possibility to configure folders for "external" modules ([#&#8203;444], thanks [@&#8203;zloirock])
#### [1.11.1] - 2016-07-20
##### Fixed
- [`newline-after-import`] exception for `switch` branches with `require`s iff parsed as `sourceType:'module'`.
  (still [#&#8203;441], thanks again [@&#8203;ljharb])
#### [1.11.0] - 2016-07-17
##### Added
- Added an `peerDependencies` option to [`no-extraneous-dependencies`] to allow/forbid peer dependencies ([#&#8203;423], [#&#8203;428], thanks [@&#8203;jfmengels]!).
##### Fixed
- [`newline-after-import`] exception for multiple `require`s in an arrow
  function expression (e.g. `() => require('a') || require('b')`). ([#&#8203;441], thanks [@&#8203;ljharb])
#### [1.10.3] - 2016-07-08
##### Fixed
- removing `Symbol` dependencies (i.e. `for-of` loops) due to Node 0.10 polyfill
  issue (see [#&#8203;415]). Should not make any discernible semantic difference.
#### [1.10.2] - 2016-07-04
##### Fixed
- Something horrible happened during `npm prepublish` of 1.10.1.
  Several `rm -rf node_modules && npm i` and `gulp clean && npm prepublish`s later, it is rebuilt and republished as 1.10.2. Thanks [@&#8203;rhettlivingston] for noticing and reporting!
#### [1.10.1] - 2016-07-02 [YANKED]
##### Added
- Officially support ESLint 3.x. (peerDependencies updated to `2.x - 3.x`)
#### [1.10.0] - 2016-06-30
##### Added
- Added new rule [`no-restricted-paths`]. ([#&#8203;155]/[#&#8203;371], thanks [@&#8203;lo1tuma])
- [`import/core-modules` setting]: allow configuration of additional module names,
  to be treated as builtin modules (a la `path`, etc. in Node). ([#&#8203;275] + [#&#8203;365], thanks [@&#8203;sindresorhus] for driving)
- React Native shared config (based on comment from [#&#8203;283])
##### Fixed
- Fixed crash with `newline-after-import` related to the use of switch cases. (fixes [#&#8203;386], thanks [@&#8203;ljharb] for reporting) ([#&#8203;395])
#### [1.9.2] - 2016-06-21
##### Fixed
- Issues with ignored/CJS files in [`export`] and [`no-deprecated`] rules. ([#&#8203;348], [#&#8203;370])
#### [1.9.1] - 2016-06-16
##### Fixed
- Reordered precedence for loading resolvers. ([#&#8203;373])
#### [1.9.0] - 2016-06-10
##### Added
- Added support TomDoc comments to [`no-deprecated`]. ([#&#8203;321], thanks [@&#8203;josh])
- Added support for loading custom resolvers ([#&#8203;314], thanks [@&#8203;le0nik])
##### Fixed
- [`prefer-default-export`] handles `export function` and `export const` in same file ([#&#8203;359], thanks [@&#8203;scottnonnenberg])
#### [1.8.1] - 2016-05-23
##### Fixed
- `export * from 'foo'` now properly ignores a `default` export from `foo`, if any. ([#&#8203;328]/[#&#8203;332], thanks [@&#8203;jkimbo])
  This impacts all static analysis of imported names. ([`default`], [`named`], [`namespace`], [`export`])
- Make [`order`]'s `newline-between` option handle multiline import statements ([#&#8203;313], thanks [@&#8203;singles])
- Make [`order`]'s `newline-between` option handle not assigned import statements ([#&#8203;313], thanks [@&#8203;singles])
- Make [`order`]'s `newline-between` option ignore `require` statements inside object literals ([#&#8203;313], thanks [@&#8203;singles])
- [`prefer-default-export`] properly handles deep destructuring, `export * from ...`, and files with no exports. ([#&#8203;342]+[#&#8203;343], thanks [@&#8203;scottnonnenberg])
#### [1.8.0] - 2016-05-11
##### Added
- [`prefer-default-export`], new rule. ([#&#8203;308], thanks [@&#8203;gavriguy])
##### Fixed
- Ignore namespace / ES7 re-exports in [`no-mutable-exports`]. ([#&#8203;317], fixed by [#&#8203;322]. thanks [@&#8203;borisyankov] + [@&#8203;jfmengels])
- Make [`no-extraneous-dependencies`] handle scoped packages ([#&#8203;316], thanks [@&#8203;jfmengels])
#### [1.7.0] - 2016-05-06
##### Added
- [`newline-after-import`], new rule. ([#&#8203;245], thanks [@&#8203;singles])
- Added an `optionalDependencies` option to [`no-extraneous-dependencies`] to allow/forbid optional dependencies ([#&#8203;266], thanks [@&#8203;jfmengels]).
- Added `newlines-between` option to [`order`] rule ([#&#8203;298], thanks [@&#8203;singles])
- add [`no-mutable-exports`] rule ([#&#8203;290], thanks [@&#8203;josh])
- [`import/extensions` setting]: a list of file extensions to parse as modules
  and search for `export`s. If unspecified, all extensions are considered valid (for now).
  In v2, this will likely default to `['.js', MODULE_EXT]`. ([#&#8203;297], to fix [#&#8203;267])
##### Fixed
- [`extensions`]: fallback to source path for extension enforcement if imported
  module is not resolved. Also, never report for builtins (i.e. `path`). ([#&#8203;296])
#### [1.6.1] - 2016-04-28
##### Fixed
- [`no-named-as-default-member`]: don't crash on rest props. ([#&#8203;281], thanks [@&#8203;SimenB])
- support for Node 6: don't pass `null` to `path` functions.
  Thanks to [@&#8203;strawbrary] for bringing this up ([#&#8203;272]) and adding OSX support to the Travis
  config ([#&#8203;288]).
#### [1.6.0] - 2016-04-25
##### Added
- add [`no-named-as-default-member`] to `warnings` canned config
- add [`no-extraneous-dependencies`] rule ([#&#8203;241], thanks [@&#8203;jfmengels])
- add [`extensions`] rule ([#&#8203;250], thanks [@&#8203;lo1tuma])
- add [`no-nodejs-modules`] rule ([#&#8203;261], thanks [@&#8203;jfmengels])
- add [`order`] rule ([#&#8203;247], thanks [@&#8203;jfmengels])
- consider `resolve.fallback` config option in the webpack resolver ([#&#8203;254])
##### Changed
- [`imports-first`] now allows directives (i.e. `'use strict'`) strictly before
  any imports ([#&#8203;256], thanks [@&#8203;lemonmade])
##### Fixed
- [`named`] now properly ignores the source module if a name is re-exported from
  an ignored file (i.e. `node_modules`). Also improved the reported error. (thanks to [@&#8203;jimbolla] for reporting)
- [`no-named-as-default-member`] had a crash on destructuring in loops (thanks for heads up from [@&#8203;lemonmade])
#### [1.5.0] - 2016-04-18
##### Added
- report resolver errors at the top of the linted file
- add [`no-namespace`] rule ([#&#8203;239], thanks [@&#8203;singles])
- add [`no-named-as-default-member`] rule ([#&#8203;243], thanks [@&#8203;dmnd])
##### Changed
- Rearranged rule groups in README in preparation for more style guide rules
##### Removed
- support for Node 0.10, via `es6-*` ponyfills. Using native Map/Set/Symbol.
#### [1.4.0] - 2016-03-25
##### Added
- Resolver plugin interface v2: more explicit response format that more clearly covers the found-but-core-module case, where there is no path.
  Still backwards-compatible with the original version of the resolver spec.
- [Resolver documentation](./resolvers/README.md)
##### Changed
- using `package.json/files` instead of `.npmignore` for package file inclusion ([#&#8203;228], thanks [@&#8203;mathieudutour])
- using `es6-*` ponyfills instead of `babel-runtime`
#### [1.3.0] - 2016-03-20
Major perf improvements. Between parsing only once and ignoring gigantic, non-module `node_modules`,
there is very little added time.

My test project takes 17s to lint completely, down from 55s, when using the
memoizing parser, and takes only 27s with naked `babel-eslint` (thus, reparsing local modules).
##### Added
- This change log ([#&#8203;216])
- Experimental memoizing [parser](./memo-parser/README.md)
##### Fixed
- Huge reduction in execution time by _only_ ignoring [`import/ignore` setting] if
  something that looks like an `export` is detected in the module content.
#### [1.2.0] - 2016-03-19
Thanks @&#8203;lencioni for identifying a huge amount of rework in resolve and kicking
off a bunch of memoization.

I'm seeing 62% improvement over my normal test codebase when executing only
[`no-unresolved`] in isolation, and ~35% total reduction in lint time.
##### Changed
- added caching to core/resolve via [#&#8203;214], configured via [`import/cache` setting]
#### [1.1.0] - 2016-03-15
##### Added
- Added an [`ignore`](./docs/rules/no-unresolved.md#ignore) option to [`no-unresolved`] for those pesky files that no
resolver can find. (still prefer enhancing the Webpack and Node resolvers to
using it, though). See [#&#8203;89] for details.
#### [1.0.4] - 2016-03-11
##### Changed
- respect hoisting for deep namespaces ([`namespace`]/[`no-deprecated`]) ([#&#8203;211])
##### Fixed
- don't crash on self references ([#&#8203;210])
- correct cache behavior in `eslint_d` for deep namespaces ([#&#8203;200])
#### [1.0.3] - 2016-02-26
##### Changed
- no-deprecated follows deep namespaces ([#&#8203;191])
##### Fixed
- [`namespace`] no longer flags modules with only a default export as having no
names. (ns.default is valid ES6)
#### [1.0.2] - 2016-02-26
##### Fixed
- don't parse imports with no specifiers ([#&#8203;192])
#### [1.0.1] - 2016-02-25
##### Fixed
- export `stage-0` shared config
- documented [`no-deprecated`]
- deep namespaces are traversed regardless of how they get imported ([#&#8203;189])
#### [1.0.0] - 2016-02-24
##### Added
- [`no-deprecated`]: WIP rule to let you know at lint time if you're using
deprecated functions, constants, classes, or modules.
##### Changed
- [`namespace`]: support deep namespaces ([#&#8203;119] via [#&#8203;157])
#### [1.0.0-beta.0] - 2016-02-13
##### Changed
- support for (only) ESLint 2.x
- no longer needs/refers to `import/parser` or `import/parse-options`. Instead,
ESLint provides the configured parser + options to the rules, and they use that
to parse dependencies.
##### Removed
- `babylon` as default import parser (see Breaking)
#### [0.13.0] - 2016-02-08
##### Added
- [`no-commonjs`] rule
- [`no-amd`] rule
##### Removed
- Removed vestigial `no-require` rule. [`no-commonjs`] is more complete.
#### [0.12.2] - 2016-02-06 [YANKED]
Unpublished from npm and re-released as 0.13.0. See [#&#8203;170].
#### [0.12.1] - 2015-12-17
##### Changed
- Broke docs for rules out into individual files.
#### [0.12.0] - 2015-12-14
##### Changed
- Ignore [`import/ignore` setting] if exports are actually found in the parsed module. Does
this to support use of `jsnext:main` in `node_modules` without the pain of
managing an allow list or a nuanced deny list.
#### [0.11.0] - 2015-11-27
##### Added
- Resolver plugins. Now the linter can read Webpack config, properly follow
aliases and ignore externals, dismisses inline loaders, etc. etc.!
#### Earlier releases (0.10.1 and younger)
See [GitHub release notes](https://github.com/benmosher/eslint-plugin-import/releases?after=v0.11.0)
for info on changes for earlier releases.


[`import/cache` setting]: ./README.md#importcache
[`import/ignore` setting]: ./README.md#importignore
[`import/extensions` setting]: ./README.md#importextensions
[`import/parsers` setting]: ./README.md#importparsers
[`import/core-modules` setting]: ./README.md#importcore-modules
[`import/external-module-folders` setting]: ./README.md#importexternal-module-folders

[`no-unresolved`]: ./docs/rules/no-unresolved.md
[`no-deprecated`]: ./docs/rules/no-deprecated.md
[`no-commonjs`]: ./docs/rules/no-commonjs.md
[`no-amd`]: ./docs/rules/no-amd.md
[`namespace`]: ./docs/rules/namespace.md
[`no-namespace`]: ./docs/rules/no-namespace.md
[`no-named-default`]: ./docs/rules/no-named-default.md
[`no-named-as-default`]: ./docs/rules/no-named-as-default.md
[`no-named-as-default-member`]: ./docs/rules/no-named-as-default-member.md
[`no-extraneous-dependencies`]: ./docs/rules/no-extraneous-dependencies.md
[`extensions`]: ./docs/rules/extensions.md
[`first`]: ./docs/rules/first.md
[`imports-first`]: ./docs/rules/first.md
[`no-nodejs-modules`]: ./docs/rules/no-nodejs-modules.md
[`order`]: ./docs/rules/order.md
[`named`]: ./docs/rules/named.md
[`default`]: ./docs/rules/default.md
[`export`]: ./docs/rules/export.md
[`newline-after-import`]: ./docs/rules/newline-after-import.md
[`no-mutable-exports`]: ./docs/rules/no-mutable-exports.md
[`prefer-default-export`]: ./docs/rules/prefer-default-export.md
[`no-restricted-paths`]: ./docs/rules/no-restricted-paths.md
[`no-absolute-path`]: ./docs/rules/no-absolute-path.md
[`max-dependencies`]: ./docs/rules/max-dependencies.md
[`no-internal-modules`]: ./docs/rules/no-internal-modules.md
[`no-dynamic-require`]: ./docs/rules/no-dynamic-require.md
[`no-webpack-loader-syntax`]: ./docs/rules/no-webpack-loader-syntax.md
[`no-unassigned-import`]: ./docs/rules/no-unassigned-import.md
[`unambiguous`]: ./docs/rules/unambiguous.md
[`no-anonymous-default-export`]: ./docs/rules/no-anonymous-default-export.md
[`exports-last`]: ./docs/rules/exports-last.md
[`group-exports`]: ./docs/rules/group-exports.md
[`no-self-import`]: ./docs/rules/no-self-import.md
[`no-default-export`]: ./docs/rules/no-default-export.md
[`no-useless-path-segments`]: ./docs/rules/no-useless-path-segments.md
[`no-cycle`]: ./docs/rules/no-cycle.md

[`memo-parser`]: ./memo-parser/README.md

[#&#8203;1068]: `https://github.com/benmosher/eslint-plugin-import/pull/1068`
[#&#8203;1046]: `https://github.com/benmosher/eslint-plugin-import/pull/1046`
[#&#8203;944]: `https://github.com/benmosher/eslint-plugin-import/pull/944`
[#&#8203;908]: `https://github.com/benmosher/eslint-plugin-import/pull/908`
[#&#8203;891]: `https://github.com/benmosher/eslint-plugin-import/pull/891`
[#&#8203;889]: `https://github.com/benmosher/eslint-plugin-import/pull/889`
[#&#8203;880]: `https://github.com/benmosher/eslint-plugin-import/pull/880`
[#&#8203;858]: `https://github.com/benmosher/eslint-plugin-import/pull/858`
[#&#8203;843]: `https://github.com/benmosher/eslint-plugin-import/pull/843`
[#&#8203;871]: `https://github.com/benmosher/eslint-plugin-import/pull/871`
[#&#8203;744]: `https://github.com/benmosher/eslint-plugin-import/pull/744`
[#&#8203;742]: `https://github.com/benmosher/eslint-plugin-import/pull/742`
[#&#8203;737]: `https://github.com/benmosher/eslint-plugin-import/pull/737`
[#&#8203;727]: `https://github.com/benmosher/eslint-plugin-import/pull/727`
[#&#8203;721]: `https://github.com/benmosher/eslint-plugin-import/pull/721`
[#&#8203;712]: `https://github.com/benmosher/eslint-plugin-import/pull/712`
[#&#8203;696]: `https://github.com/benmosher/eslint-plugin-import/pull/696`
[#&#8203;685]: `https://github.com/benmosher/eslint-plugin-import/pull/685`
[#&#8203;680]: `https://github.com/benmosher/eslint-plugin-import/pull/680`
[#&#8203;654]: `https://github.com/benmosher/eslint-plugin-import/pull/654`
[#&#8203;639]: `https://github.com/benmosher/eslint-plugin-import/pull/639`
[#&#8203;632]: `https://github.com/benmosher/eslint-plugin-import/pull/632`
[#&#8203;630]: `https://github.com/benmosher/eslint-plugin-import/pull/630`
[#&#8203;628]: `https://github.com/benmosher/eslint-plugin-import/pull/628`
[#&#8203;596]: `https://github.com/benmosher/eslint-plugin-import/pull/596`
[#&#8203;586]: `https://github.com/benmosher/eslint-plugin-import/pull/586`
[#&#8203;578]: `https://github.com/benmosher/eslint-plugin-import/pull/578`
[#&#8203;568]: `https://github.com/benmosher/eslint-plugin-import/pull/568`
[#&#8203;555]: `https://github.com/benmosher/eslint-plugin-import/pull/555`
[#&#8203;538]: `https://github.com/benmosher/eslint-plugin-import/pull/538`
[#&#8203;527]: `https://github.com/benmosher/eslint-plugin-import/pull/527`
[#&#8203;509]: `https://github.com/benmosher/eslint-plugin-import/pull/509`
[#&#8203;508]: `https://github.com/benmosher/eslint-plugin-import/pull/508`
[#&#8203;503]: `https://github.com/benmosher/eslint-plugin-import/pull/503`
[#&#8203;499]: `https://github.com/benmosher/eslint-plugin-import/pull/499`
[#&#8203;489]: `https://github.com/benmosher/eslint-plugin-import/pull/489`
[#&#8203;485]: `https://github.com/benmosher/eslint-plugin-import/pull/485`
[#&#8203;461]: `https://github.com/benmosher/eslint-plugin-import/pull/461`
[#&#8203;449]: `https://github.com/benmosher/eslint-plugin-import/pull/449`
[#&#8203;444]: `https://github.com/benmosher/eslint-plugin-import/pull/444`
[#&#8203;428]: `https://github.com/benmosher/eslint-plugin-import/pull/428`
[#&#8203;395]: `https://github.com/benmosher/eslint-plugin-import/pull/395`
[#&#8203;371]: `https://github.com/benmosher/eslint-plugin-import/pull/371`
[#&#8203;365]: `https://github.com/benmosher/eslint-plugin-import/pull/365`
[#&#8203;359]: `https://github.com/benmosher/eslint-plugin-import/pull/359`
[#&#8203;343]: `https://github.com/benmosher/eslint-plugin-import/pull/343`
[#&#8203;332]: `https://github.com/benmosher/eslint-plugin-import/pull/332`
[#&#8203;322]: `https://github.com/benmosher/eslint-plugin-import/pull/322`
[#&#8203;321]: `https://github.com/benmosher/eslint-plugin-import/pull/321`
[#&#8203;316]: `https://github.com/benmosher/eslint-plugin-import/pull/316`
[#&#8203;308]: `https://github.com/benmosher/eslint-plugin-import/pull/308`
[#&#8203;298]: `https://github.com/benmosher/eslint-plugin-import/pull/298`
[#&#8203;297]: `https://github.com/benmosher/eslint-plugin-import/pull/297`
[#&#8203;296]: `https://github.com/benmosher/eslint-plugin-import/pull/296`
[#&#8203;290]: `https://github.com/benmosher/eslint-plugin-import/pull/290`
[#&#8203;289]: `https://github.com/benmosher/eslint-plugin-import/pull/289`
[#&#8203;288]: `https://github.com/benmosher/eslint-plugin-import/pull/288`
[#&#8203;287]: `https://github.com/benmosher/eslint-plugin-import/pull/287`
[#&#8203;278]: `https://github.com/benmosher/eslint-plugin-import/pull/278`
[#&#8203;261]: `https://github.com/benmosher/eslint-plugin-import/pull/261`
[#&#8203;256]: `https://github.com/benmosher/eslint-plugin-import/pull/256`
[#&#8203;254]: `https://github.com/benmosher/eslint-plugin-import/pull/254`
[#&#8203;250]: `https://github.com/benmosher/eslint-plugin-import/pull/250`
[#&#8203;247]: `https://github.com/benmosher/eslint-plugin-import/pull/247`
[#&#8203;245]: `https://github.com/benmosher/eslint-plugin-import/pull/245`
[#&#8203;243]: `https://github.com/benmosher/eslint-plugin-import/pull/243`
[#&#8203;241]: `https://github.com/benmosher/eslint-plugin-import/pull/241`
[#&#8203;239]: `https://github.com/benmosher/eslint-plugin-import/pull/239`
[#&#8203;228]: `https://github.com/benmosher/eslint-plugin-import/pull/228`
[#&#8203;211]: `https://github.com/benmosher/eslint-plugin-import/pull/211`
[#&#8203;164]: `https://github.com/benmosher/eslint-plugin-import/pull/164`
[#&#8203;157]: `https://github.com/benmosher/eslint-plugin-import/pull/157`
[#&#8203;314]: `https://github.com/benmosher/eslint-plugin-import/pull/314`
[#&#8203;912]: `https://github.com/benmosher/eslint-plugin-import/pull/912`

[#&#8203;1058]: `https://github.com/benmosher/eslint-plugin-import/issues/1058`
[#&#8203;931]: `https://github.com/benmosher/eslint-plugin-import/issues/931`
[#&#8203;886]: `https://github.com/benmosher/eslint-plugin-import/issues/886`
[#&#8203;863]: `https://github.com/benmosher/eslint-plugin-import/issues/863`
[#&#8203;842]: `https://github.com/benmosher/eslint-plugin-import/issues/842`
[#&#8203;839]: `https://github.com/benmosher/eslint-plugin-import/issues/839`
[#&#8203;720]: `https://github.com/benmosher/eslint-plugin-import/issues/720`
[#&#8203;686]: `https://github.com/benmosher/eslint-plugin-import/issues/686`
[#&#8203;671]: `https://github.com/benmosher/eslint-plugin-import/issues/671`
[#&#8203;660]: `https://github.com/benmosher/eslint-plugin-import/issues/660`
[#&#8203;653]: `https://github.com/benmosher/eslint-plugin-import/issues/653`
[#&#8203;627]: `https://github.com/benmosher/eslint-plugin-import/issues/627`
[#&#8203;620]: `https://github.com/benmosher/eslint-plugin-import/issues/620`
[#&#8203;609]: `https://github.com/benmosher/eslint-plugin-import/issues/609`
[#&#8203;604]: `https://github.com/benmosher/eslint-plugin-import/issues/604`
[#&#8203;602]: `https://github.com/benmosher/eslint-plugin-import/issues/602`
[#&#8203;601]: `https://github.com/benmosher/eslint-plugin-import/issues/601`
[#&#8203;592]: `https://github.com/benmosher/eslint-plugin-import/issues/592`
[#&#8203;577]: `https://github.com/benmosher/eslint-plugin-import/issues/577`
[#&#8203;570]: `https://github.com/benmosher/eslint-plugin-import/issues/570`
[#&#8203;567]: `https://github.com/benmosher/eslint-plugin-import/issues/567`
[#&#8203;566]: `https://github.com/benmosher/eslint-plugin-import/issues/566`
[#&#8203;545]: `https://github.com/benmosher/eslint-plugin-import/issues/545`
[#&#8203;530]: `https://github.com/benmosher/eslint-plugin-import/issues/530`
[#&#8203;529]: `https://github.com/benmosher/eslint-plugin-import/issues/529`
[#&#8203;519]: `https://github.com/benmosher/eslint-plugin-import/issues/519`
[#&#8203;507]: `https://github.com/benmosher/eslint-plugin-import/issues/507`
[#&#8203;484]: `https://github.com/benmosher/eslint-plugin-import/issues/484`
[#&#8203;478]: `https://github.com/benmosher/eslint-plugin-import/issues/478`
[#&#8203;456]: `https://github.com/benmosher/eslint-plugin-import/issues/456`
[#&#8203;453]: `https://github.com/benmosher/eslint-plugin-import/issues/453`
[#&#8203;452]: `https://github.com/benmosher/eslint-plugin-import/issues/452`
[#&#8203;447]: `https://github.com/benmosher/eslint-plugin-import/issues/447`
[#&#8203;441]: `https://github.com/benmosher/eslint-plugin-import/issues/441`
[#&#8203;423]: `https://github.com/benmosher/eslint-plugin-import/issues/423`
[#&#8203;416]: `https://github.com/benmosher/eslint-plugin-import/issues/416`
[#&#8203;415]: `https://github.com/benmosher/eslint-plugin-import/issues/415`
[#&#8203;402]: `https://github.com/benmosher/eslint-plugin-import/issues/402`
[#&#8203;386]: `https://github.com/benmosher/eslint-plugin-import/issues/386`
[#&#8203;373]: `https://github.com/benmosher/eslint-plugin-import/issues/373`
[#&#8203;370]: `https://github.com/benmosher/eslint-plugin-import/issues/370`
[#&#8203;348]: `https://github.com/benmosher/eslint-plugin-import/issues/348`
[#&#8203;342]: `https://github.com/benmosher/eslint-plugin-import/issues/342`
[#&#8203;328]: `https://github.com/benmosher/eslint-plugin-import/issues/328`
[#&#8203;317]: `https://github.com/benmosher/eslint-plugin-import/issues/317`
[#&#8203;313]: `https://github.com/benmosher/eslint-plugin-import/issues/313`
[#&#8203;311]: `https://github.com/benmosher/eslint-plugin-import/issues/311`
[#&#8203;306]: `https://github.com/benmosher/eslint-plugin-import/issues/306`
[#&#8203;286]: `https://github.com/benmosher/eslint-plugin-import/issues/286`
[#&#8203;283]: `https://github.com/benmosher/eslint-plugin-import/issues/283`
[#&#8203;281]: `https://github.com/benmosher/eslint-plugin-import/issues/281`
[#&#8203;275]: `https://github.com/benmosher/eslint-plugin-import/issues/275`
[#&#8203;272]: `https://github.com/benmosher/eslint-plugin-import/issues/272`
[#&#8203;270]: `https://github.com/benmosher/eslint-plugin-import/issues/270`
[#&#8203;267]: `https://github.com/benmosher/eslint-plugin-import/issues/267`
[#&#8203;266]: `https://github.com/benmosher/eslint-plugin-import/issues/266`
[#&#8203;216]: `https://github.com/benmosher/eslint-plugin-import/issues/216`
[#&#8203;214]: `https://github.com/benmosher/eslint-plugin-import/issues/214`
[#&#8203;210]: `https://github.com/benmosher/eslint-plugin-import/issues/210`
[#&#8203;200]: `https://github.com/benmosher/eslint-plugin-import/issues/200`
[#&#8203;192]: `https://github.com/benmosher/eslint-plugin-import/issues/192`
[#&#8203;191]: `https://github.com/benmosher/eslint-plugin-import/issues/191`
[#&#8203;189]: `https://github.com/benmosher/eslint-plugin-import/issues/189`
[#&#8203;170]: `https://github.com/benmosher/eslint-plugin-import/issues/170`
[#&#8203;155]: `https://github.com/benmosher/eslint-plugin-import/issues/155`
[#&#8203;119]: `https://github.com/benmosher/eslint-plugin-import/issues/119`
[#&#8203;89]: `https://github.com/benmosher/eslint-plugin-import/issues/89`

[Unreleased]: https://github.com/benmosher/eslint-plugin-import/compare/v2.11.0...HEAD
[2.11.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.10.0...v2.11.0
[2.10.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.9.0...v2.10.0
[2.9.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.8.0...v2.9.0
[2.8.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.7.0...v2.8.0
[2.7.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.6.1...v2.7.0
[2.6.1]: https://github.com/benmosher/eslint-plugin-import/compare/v2.6.0...v2.6.1
[2.6.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.5.0...v2.6.0
[2.5.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.4.0...v2.5.0
[2.4.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.3.0...v2.4.0
[2.3.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.2.0...v2.3.0
[2.2.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.1.0...v2.2.0
[2.1.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.0.1...v2.1.0
[2.0.1]: https://github.com/benmosher/eslint-plugin-import/compare/v2.0.0...v2.0.1
[2.0.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.16.0...v2.0.0
[1.16.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.15.0...v1.16.0
[1.15.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.14.0...v1.15.0
[1.14.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.13.0...v1.14.0
[1.13.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.12.0...v1.13.0
[1.12.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.11.1...v1.12.0
[1.11.1]: https://github.com/benmosher/eslint-plugin-import/compare/v1.11.0...v1.11.1
[1.11.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.10.3...v1.11.0
[1.10.3]: https://github.com/benmosher/eslint-plugin-import/compare/v1.10.2...v1.10.3
[1.10.2]: https://github.com/benmosher/eslint-plugin-import/compare/v1.10.1...v1.10.2
[1.10.1]: https://github.com/benmosher/eslint-plugin-import/compare/v1.10.0...v1.10.1
[1.10.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.9.2...v1.10.0
[1.9.2]: https://github.com/benmosher/eslint-plugin-import/compare/v1.9.1...v1.9.2
[1.9.1]: https://github.com/benmosher/eslint-plugin-import/compare/v1.9.0...v1.9.1
[1.9.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.8.1...v1.9.0
[1.8.1]: https://github.com/benmosher/eslint-plugin-import/compare/v1.8.0...v1.8.1
[1.8.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.7.0...v1.8.0
[1.7.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.6.1...v1.7.0
[1.6.1]: https://github.com/benmosher/eslint-plugin-import/compare/v1.6.0...v1.6.1
[1.6.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.5.0...1.6.0
[1.5.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.4.0...v1.5.0
[1.4.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.3.0...v1.4.0
[1.3.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.2.0...v1.3.0
[1.2.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.1.0...v1.2.0
[1.1.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.0.4...v1.1.0
[1.0.4]: https://github.com/benmosher/eslint-plugin-import/compare/v1.0.3...v1.0.4
[1.0.3]: https://github.com/benmosher/eslint-plugin-import/compare/v1.0.2...v1.0.3
[1.0.2]: https://github.com/benmosher/eslint-plugin-import/compare/v1.0.1...v1.0.2
[1.0.1]: https://github.com/benmosher/eslint-plugin-import/compare/v1.0.0...v1.0.1
[1.0.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.0.0-beta.0...v1.0.0
[1.0.0-beta.0]: https://github.com/benmosher/eslint-plugin-import/compare/v0.13.0...v1.0.0-beta.0
[0.13.0]: https://github.com/benmosher/eslint-plugin-import/compare/v0.12.1...v0.13.0
[0.12.2]: https://github.com/benmosher/eslint-plugin-import/compare/v0.12.1...v0.12.2
[0.12.1]: https://github.com/benmosher/eslint-plugin-import/compare/v0.12.0...v0.12.1
[0.12.0]: https://github.com/benmosher/eslint-plugin-import/compare/v0.11.0...v0.12.0
[0.11.0]: https://github.com/benmosher/eslint-plugin-import/compare/v0.10.1...v0.11.0

[@&#8203;mathieudutour]: https://github.com/mathieudutour
[@&#8203;gausie]: https://github.com/gausie
[@&#8203;singles]: https://github.com/singles
[@&#8203;jfmengels]: https://github.com/jfmengels
[@&#8203;lo1tuma]: https://github.com/lo1tuma
[@&#8203;dmnd]: https://github.com/dmnd
[@&#8203;lemonmade]: https://github.com/lemonmade
[@&#8203;jimbolla]: https://github.com/jimbolla
[@&#8203;jquense]: https://github.com/jquense
[@&#8203;jonboiser]: https://github.com/jonboiser
[@&#8203;taion]: https://github.com/taion
[@&#8203;strawbrary]: https://github.com/strawbrary
[@&#8203;SimenB]: https://github.com/SimenB
[@&#8203;josh]: https://github.com/josh
[@&#8203;borisyankov]: https://github.com/borisyankov
[@&#8203;gavriguy]: https://github.com/gavriguy
[@&#8203;jkimbo]: https://github.com/jkimbo
[@&#8203;le0nik]: https://github.com/le0nik
[@&#8203;scottnonnenberg]: https://github.com/scottnonnenberg
[@&#8203;sindresorhus]: https://github.com/sindresorhus
[@&#8203;ljharb]: https://github.com/ljharb
[@&#8203;rhettlivingston]: https://github.com/rhettlivingston
[@&#8203;zloirock]: https://github.com/zloirock
[@&#8203;rhys-vdw]: https://github.com/rhys-vdw
[@&#8203;wKich]: https://github.com/wKich
[@&#8203;tizmagik]: https://github.com/tizmagik
[@&#8203;knpwrs]: https://github.com/knpwrs
[@&#8203;spalger]: https://github.com/spalger
[@&#8203;preco21]: https://github.com/preco21
[@&#8203;skyrpex]: https://github.com/skyrpex
[@&#8203;fson]: https://github.com/fson
[@&#8203;ntdb]: https://github.com/ntdb
[@&#8203;jakubsta]: https://github.com/jakubsta
[@&#8203;wtgtybhertgeghgtwtg]: https://github.com/wtgtybhertgeghgtwtg
[@&#8203;duncanbeevers]: https://github.com/duncanbeevers
[@&#8203;giodamelio]: https://github.com/giodamelio
[@&#8203;ntdb]: https://github.com/ntdb
[@&#8203;ramasilveyra]: https://github.com/ramasilveyra
[@&#8203;sompylasar]: https://github.com/sompylasar
[@&#8203;kevin940726]: https://github.com/kevin940726
[@&#8203;eelyafi]: https://github.com/eelyafi
[@&#8203;mastilver]: https://github.com/mastilver
[@&#8203;jseminck]: https://github.com/jseminck
[@&#8203;laysent]: https://github.com/laysent
[@&#8203;k15a]: https://github.com/k15a
[@&#8203;mplewis]: https://github.com/mplewis
[@&#8203;rosswarren]: https://github.com/rosswarren
[@&#8203;alexgorbatchev]: https://github.com/alexgorbatchev
[@&#8203;tihonove]: https://github.com/tihonove
[@&#8203;robertrossmann]: https://github.com/robertrossmann
[@&#8203;isiahmeadows]: https://github.com/isiahmeadows
[@&#8203;graingert]: https://github.com/graingert
[@&#8203;danny-andrews]: https://github.com/dany-andrews
[@&#8203;fengkfengk]: https://github.com/fengkfengk
[@&#8203;futpib]: https://github.com/futpib
[@&#8203;klimashkin]: https://github.com/klimashkin
[@&#8203;lukeapage]: https://github.com/lukeapage
[@&#8203;manovotny]: https://github.com/manovotny
[@&#8203;mattijsbliek]: https://github.com/mattijsbliek

---

</details>